### PR TITLE
Allow removing dicts

### DIFF
--- a/dict_test.go
+++ b/dict_test.go
@@ -603,7 +603,7 @@ func TestParsedDictContentSize(t *testing.T) {
 
 func TestRawDictSmall(t *testing.T) {
 	src := bytes.Repeat([]byte("small dict edge case "), 50)
-	for _, sz := range []int{1, 8, 16} {
+	for _, sz := range []int{8, 16} {
 		t.Run("", func(t *testing.T) {
 			dictContent := bytes.Repeat([]byte("x"), sz)
 			w := NewWriter(nil)
@@ -621,6 +621,38 @@ func TestRawDictSmall(t *testing.T) {
 				t.Fatal("mismatch")
 			}
 		})
+	}
+}
+
+func TestRawDictTooShortIgnored(t *testing.T) {
+	src := bytes.Repeat([]byte("short dict ignored "), 50)
+
+	// Compress without dict.
+	w := NewWriter(nil)
+	want := w.AppendCompress(nil, src)
+
+	// SetRawDict with < 8 bytes should be silently ignored.
+	for _, sz := range []int{1, 4, 7} {
+		t.Run("", func(t *testing.T) {
+			w2 := NewWriter(nil)
+			w2.SetRawDict(bytes.Repeat([]byte("x"), sz))
+			got := w2.AppendCompress(nil, src)
+			if !bytes.Equal(got, want) {
+				t.Fatalf("sz=%d: short dict was not ignored (output differs)", sz)
+			}
+		})
+	}
+
+	// Reader side: short dict should not register.
+	r, _ := NewReader(nil)
+	r.SetRawDict(bytes.Repeat([]byte("x"), 3))
+	got, err := r.AppendDecompress(nil, want)
+	_ = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("reader mismatch")
 	}
 }
 
@@ -651,6 +683,165 @@ func TestDictWriterReuseAcrossReset(t *testing.T) {
 				t.Fatal("mismatch")
 			}
 		})
+	}
+}
+
+func TestReaderAddDictNilClear(t *testing.T) {
+	raw := loadTestDict(t)
+	d, err := ParseDict(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := bytes.Repeat([]byte("reader add dict nil clear "), 50)
+
+	w := NewWriter(nil)
+	w.AddDict(d)
+	compressed := w.AppendCompress(nil, src)
+
+	r, err := NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.AddDict(d)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch before clear")
+	}
+
+	r.AddDict(nil)
+	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(r)
+	_ = r.Close()
+	if err != ErrUnknownDictionary {
+		t.Fatalf("expected ErrUnknownDictionary, got: %v", err)
+	}
+}
+
+func TestReaderSetRawDictNilClear(t *testing.T) {
+	raw := loadTestDict(t)
+	d, err := ParseDict(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := bytes.Repeat([]byte("reader raw dict nil clear "), 50)
+
+	w := NewWriter(nil)
+	w.AddDict(d)
+	compressed := w.AppendCompress(nil, src)
+
+	r, err := NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.AddDict(d)
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch before clear")
+	}
+
+	r.SetRawDict(nil) // clear all dicts
+	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(r)
+	_ = r.Close()
+	if err != ErrUnknownDictionary {
+		t.Fatalf("expected ErrUnknownDictionary, got: %v", err)
+	}
+}
+
+func TestReaderNilClearMultipleDicts(t *testing.T) {
+	raw := loadTestDict(t)
+	d, err := ParseDict(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dictContent := bytes.Repeat([]byte("raw dict for multi clear "), 100)
+	src := bytes.Repeat([]byte("multi dict clear test "), 50)
+
+	// Compress with parsed dict.
+	wParsed := NewWriter(nil)
+	wParsed.AddDict(d)
+	compParsed := wParsed.AppendCompress(nil, src)
+
+	// Compress with raw dict.
+	wRaw := NewWriter(nil)
+	wRaw.SetRawDict(dictContent)
+	compRaw := wRaw.AppendCompress(nil, src)
+
+	r, err := NewReader(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.AddDict(d)
+	r.SetRawDict(dictContent)
+
+	// Both should decode.
+	got, err := r.AppendDecompress(nil, compParsed)
+	if err != nil {
+		t.Fatalf("parsed dict decode: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("parsed dict mismatch")
+	}
+	got, err = r.AppendDecompress(nil, compRaw)
+	if err != nil {
+		t.Fatalf("raw dict decode: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("raw dict mismatch")
+	}
+
+	r.AddDict(nil) // clear all
+
+	_, err = r.AppendDecompress(nil, compParsed)
+	if err != ErrUnknownDictionary {
+		t.Fatalf("parsed dict after clear: expected ErrUnknownDictionary, got: %v", err)
+	}
+	_, err = r.AppendDecompress(nil, compRaw)
+	_ = r.Close()
+	// Raw dict (ID 0) doesn't embed a dict ID in the frame, so the error
+	// is a corruption from bad offsets rather than ErrUnknownDictionary.
+	if !errors.Is(err, &ErrCorrupted{}) {
+		t.Fatalf("raw dict after clear: expected ErrCorrupted, got: %v", err)
+	}
+}
+
+func TestWriterSetRawDictNilClear(t *testing.T) {
+	dictContent := bytes.Repeat([]byte("dict content "), 50)
+	src := []byte("hello world, compressed without dict")
+
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+	w.SetRawDict(dictContent)
+	w.SetRawDict(nil) // clear dict
+	w.Reset(&buf)
+	if _, err := w.Write(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := NewReader(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(r)
+	_ = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch")
 	}
 }
 

--- a/reader.go
+++ b/reader.go
@@ -48,6 +48,7 @@ func NewReader(r io.Reader) (*Reader, error) {
 }
 
 // Reset discards the Reader's state and makes it read from r.
+// Configuration is preserved.
 // If r is nil, Reset is equivalent to [Reader.Close].
 func (z *Reader) Reset(r io.Reader) error {
 	z.ensureInit()
@@ -204,8 +205,9 @@ func (z *Reader) AppendDecompress(dst, src []byte) ([]byte, error) {
 	}
 }
 
-// Close releases resources. After Close, the Reader may be reused by
-// calling [Reader.Reset].
+// Close releases resources but retains configuration.
+// After Close, the Reader may be reused by calling
+// [Reader.Reset].
 func (z *Reader) Close() error {
 	z.ensureInit()
 	z.err = ErrDecoderClosed
@@ -223,9 +225,14 @@ func (z *Reader) SetMaxWindowSize(n uint64) {
 }
 
 // AddDict registers a dictionary for decompression.
+// Sending nil will delete all previously registered dictionaries.
 func (z *Reader) AddDict(d *Dict) {
 	z.ensureInit()
 	if d == nil || d.d == nil {
+		if d == nil {
+			clear(z.dicts)
+			return
+		}
 		return
 	}
 	if z.dicts == nil {
@@ -235,8 +242,17 @@ func (z *Reader) AddDict(d *Dict) {
 }
 
 // SetRawDict registers raw bytes as a dictionary with ID 0.
+// The dictionary must be at least 8 bytes.
+// Sending nil will delete all previously registered dictionaries.
 func (z *Reader) SetRawDict(b []byte) {
 	z.ensureInit()
+	if b == nil {
+		clear(z.dicts)
+		return
+	}
+	if len(b) < 8 {
+		b = nil
+	}
 	if z.dicts == nil {
 		z.dicts = make(map[uint32]*dict)
 	}

--- a/writer.go
+++ b/writer.go
@@ -170,6 +170,7 @@ func (w *Writer) SetCRC(b bool) {
 }
 
 // AddDict registers a parsed dictionary for compression.
+// Sending nil removes the previous dictionary.
 func (w *Writer) AddDict(d *Dict) {
 	w.ensureInit()
 	if d == nil {
@@ -180,9 +181,11 @@ func (w *Writer) AddDict(d *Dict) {
 }
 
 // SetRawDict registers raw bytes as a dictionary prefix.
+// The dictionary must be at least 8 bytes; shorter will not be used.
+// Sending nil removes any previous dictionary.
 func (w *Writer) SetRawDict(b []byte) {
 	w.ensureInit()
-	if len(b) == 0 {
+	if len(b) < 8 {
 		w.dict = nil
 		return
 	}
@@ -201,7 +204,7 @@ func (w *Writer) ResetContentSize(wr io.Writer, size int64) {
 }
 
 // Reset discards the Writer's state and prepares it to write a new frame
-// to wr. Configuration (level, window size, CRC, dictionary) is preserved.
+// to wr. Configuration is preserved.
 func (w *Writer) Reset(wr io.Writer) {
 	w.ensureInit()
 	if cap(w.filling) == 0 {


### PR DESCRIPTION
Sending 'nil' will allow to "unregister" dictionaries.

Furthermore don't use dictionaries that are < 8 bytes as per [spec](https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#dictionary-format).

> Zstandard is compatible with "raw content" dictionaries, free of any format restriction, except that they must be at least 8 bytes. These dictionaries function as if they were just the Content part of a formatted dictionary.

Setting such a dictionary will just remove the previous "raw" dictionary.

Updates docs on settings. In particular dictionaries.

Fixes #10

(not seeing this as contentious, so I will merge if no-one has objections/changes)