### PR TITLE
Adjust window sizes

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -116,39 +116,36 @@ func (w *Writer) SetLevel(level int) error {
 		return fmt.Errorf("zstd: invalid level %d", level)
 	}
 	w.level = level
+	w.blockSize = maxCompressedBlockSize
+	// These mirror zstd default window sizes at levels 1, 3 and 9.
 	switch level {
 	case 0:
 		w.wndSize = 0
-		w.blockSize = maxCompressedBlockSize
 	case 1:
-		w.wndSize = 4 << 20
-		w.blockSize = 1 << 16
+		w.wndSize = 2 << 20
 	case 2:
-		w.wndSize = 8 << 20
-		w.blockSize = 1 << 16
+		w.wndSize = 3 << 20
 	case 3:
 		w.wndSize = 4 << 20
-		w.blockSize = maxCompressedBlockSize
 	case 4:
-		w.wndSize = 8 << 20
-		w.blockSize = maxCompressedBlockSize
-	case 5, 6:
-		w.wndSize = 8 << 20
-		w.blockSize = maxCompressedBlockSize
+		w.wndSize = 4 << 20
+	case 5:
+		w.wndSize = 4 << 20
+	case 6:
+		w.wndSize = 5 << 20
 	case 7:
-		w.wndSize = 8 << 20
-		w.blockSize = maxCompressedBlockSize
+		w.wndSize = 6 << 20
 	case 8:
-		w.wndSize = 8 << 20
-		w.blockSize = maxCompressedBlockSize
+		w.wndSize = 7 << 20
 	case 9:
 		w.wndSize = 8 << 20
-		w.blockSize = maxCompressedBlockSize
 	}
 	return nil
 }
 
 // SetWindowSize overrides the window size for compression.
+// This allows limiting memory usage both for compression and decompression.
+//
 // n must be in the range [MinWindowSize, MaxWindowSize].
 func (w *Writer) SetWindowSize(n int) error {
 	w.ensureInit()


### PR DESCRIPTION
Base window sizes off zstd default sizes at levels 1,3 and 9.

Values in-between are also in-between, since it is the only real tweak we have.

Compression typically goes up with bigger windows, but speed also a tiny bit since there are more matches.

No real point in small blocks. Not faster, less compression.

A few examples:

```
file	out	level	insize	outsize	millis	mb/s
gob-stream	stdzstd	1	1911399616	231560484	2549	715.06
gob-stream	stdzstd	2	1911399616	230900340	2507	726.91
gob-stream	stdzstd	3	1911399616	206212519	3063	595.06
gob-stream	stdzstd	4	1911399616	206212519	3089	589.98
gob-stream	stdzstd	5	1911399616	180368841	5508	330.89
gob-stream	stdzstd	6	1911399616	178501256	5409	336.99
gob-stream	stdzstd	7	1911399616	176751144	5513	330.59
gob-stream	stdzstd	8	1911399616	163149652	24902	73.20
gob-stream	stdzstd	9	1911399616	162144598	23423	77.82

file	out	level	insize	outsize	millis	mb/s
silesia.tar	stdzstd	1	211947520	74195853	535	377.35
silesia.tar	stdzstd	2	211947520	74102270	532	379.42
silesia.tar	stdzstd	3	211947520	67696501	750	269.15
silesia.tar	stdzstd	4	211947520	67696501	787	256.52
silesia.tar	stdzstd	5	211947520	64844483	1119	180.51
silesia.tar	stdzstd	6	211947520	64786009	1116	181.05
silesia.tar	stdzstd	7	211947520	64734349	1110	182.03
silesia.tar	stdzstd	8	211947520	59618821	6562	30.80
silesia.tar	stdzstd	9	211947520	59560745	6629	30.49

file	out	level	insize	outsize	millis	mb/s
enwik9	stdzstd	1	1000000000	343942235	3110	306.62
enwik9	stdzstd	2	1000000000	343870428	3130	304.63
enwik9	stdzstd	3	1000000000	317109707	4004	238.13
enwik9	stdzstd	4	1000000000	317109707	4023	237.01
enwik9	stdzstd	5	1000000000	292700656	6560	145.36
enwik9	stdzstd	6	1000000000	292267632	6149	155.08
enwik9	stdzstd	7	1000000000	291786526	6133	155.49
enwik9	stdzstd	8	1000000000	264571048	31285	30.48
enwik9	stdzstd	9	1000000000	263454097	29855	31.94

file	out	level	insize	outsize	millis	mb/s
github-june-2days-2019.json	stdzstd	1	6273951764	705182067	8029	745.18
github-june-2days-2019.json	stdzstd	2	6273951764	695900914	7818	765.29
github-june-2days-2019.json	stdzstd	3	6273951764	633816912	9598	623.39
github-june-2days-2019.json	stdzstd	4	6273951764	633816912	9484	630.87
github-june-2days-2019.json	stdzstd	5	6273951764	579955356	18417	324.87
github-june-2days-2019.json	stdzstd	6	6273951764	568931745	17698	338.06
github-june-2days-2019.json	stdzstd	7	6273951764	559704197	17196	347.95
github-june-2days-2019.json	stdzstd	8	6273951764	529987118	66110	90.50
github-june-2days-2019.json	stdzstd	9	6273951764	522934301	66654	89.77
```

Fixes #2