### PR TITLE
xxhash: Allow register use

### DIFF
--- a/internal/xxhash/xxhash.go
+++ b/internal/xxhash/xxhash.go
@@ -70,23 +70,29 @@ func (xh *Digest) update(b []byte) {
 		return
 	}
 
+	// Move values to registers. ~10% faster.
+	v0, v1, v2, v3 := xh.v[0], xh.v[1], xh.v[2], xh.v[3]
 	if xh.cnt > 0 {
 		n := copy(xh.buf[xh.cnt:], b)
 		b = b[n:]
-		xh.v[0] = xh.round(xh.v[0], binary.LittleEndian.Uint64(xh.buf[:]))
-		xh.v[1] = xh.round(xh.v[1], binary.LittleEndian.Uint64(xh.buf[8:]))
-		xh.v[2] = xh.round(xh.v[2], binary.LittleEndian.Uint64(xh.buf[16:]))
-		xh.v[3] = xh.round(xh.v[3], binary.LittleEndian.Uint64(xh.buf[24:]))
+		v0 = xh.round(v0, binary.LittleEndian.Uint64(xh.buf[:]))
+		v1 = xh.round(v1, binary.LittleEndian.Uint64(xh.buf[8:]))
+		v2 = xh.round(v2, binary.LittleEndian.Uint64(xh.buf[16:]))
+		v3 = xh.round(v3, binary.LittleEndian.Uint64(xh.buf[24:]))
 		xh.cnt = 0
 	}
 
 	for len(b) >= 32 {
-		xh.v[0] = xh.round(xh.v[0], binary.LittleEndian.Uint64(b))
-		xh.v[1] = xh.round(xh.v[1], binary.LittleEndian.Uint64(b[8:]))
-		xh.v[2] = xh.round(xh.v[2], binary.LittleEndian.Uint64(b[16:]))
-		xh.v[3] = xh.round(xh.v[3], binary.LittleEndian.Uint64(b[24:]))
+		v0 = xh.round(v0, binary.LittleEndian.Uint64(b))
+		v1 = xh.round(v1, binary.LittleEndian.Uint64(b[8:]))
+		v2 = xh.round(v2, binary.LittleEndian.Uint64(b[16:]))
+		v3 = xh.round(v3, binary.LittleEndian.Uint64(b[24:]))
 		b = b[32:]
 	}
+	xh.v[0] = v0
+	xh.v[1] = v1
+	xh.v[2] = v2
+	xh.v[3] = v3
 
 	if len(b) > 0 {
 		copy(xh.buf[:], b)

--- a/internal/xxhash/xxhash_test.go
+++ b/internal/xxhash/xxhash_test.go
@@ -7,6 +7,7 @@ package xxhash
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"testing"
 )
 
@@ -130,5 +131,23 @@ func TestSumAppend(t *testing.T) {
 	}
 	if len(result) != len(prefix)+8 {
 		t.Errorf("Sum result length = %d, want %d", len(result), len(prefix)+8)
+	}
+}
+
+func BenchmarkSum64(b *testing.B) {
+	for _, sz := range []int{16, 1 << 10, 4 << 10, 1 + 4<<10, 64 << 10, 1 << 20, 16 << 20} {
+		in := make([]byte, sz)
+		for i := range in {
+			in[i] = byte(i)
+		}
+		d := New()
+		b.Run(fmt.Sprint("sz=", sz), func(b *testing.B) {
+			b.SetBytes(int64(sz))
+			d.Reset()
+			for i := 0; i < b.N; i++ {
+				_, _ = d.Write(in)
+				_ = d.Sum64()
+			}
+		})
 	}
 }


### PR DESCRIPTION
Before/After:

```
BenchmarkSum64/sz=16-32                 182602153                6.581 ns/op    2431.15 MB/s
BenchmarkSum64/sz=1024-32               26413566                45.69 ns/op     22412.22 MB/s
BenchmarkSum64/sz=4096-32                7001349               169.7 ns/op      24139.16 MB/s
BenchmarkSum64/sz=4097-32                6464913               184.6 ns/op      22197.27 MB/s
BenchmarkSum64/sz=65536-32                450775              2674 ns/op        24504.11 MB/s
BenchmarkSum64/sz=1048576-32               28075             42834 ns/op        24480.23 MB/s
BenchmarkSum64/sz=16777216-32               1754            689001 ns/op        24350.07 MB/s

BenchmarkSum64/sz=16-32                 185920084                6.496 ns/op    2463.23 MB/s
BenchmarkSum64/sz=1024-32               29311257                40.99 ns/op     24984.31 MB/s
BenchmarkSum64/sz=4096-32                7837404               152.6 ns/op      26847.05 MB/s
BenchmarkSum64/sz=4097-32                7280152               163.9 ns/op      24993.61 MB/s
BenchmarkSum64/sz=65536-32                517695              2323 ns/op        28216.37 MB/s
BenchmarkSum64/sz=1048576-32               32419             36960 ns/op        28370.37 MB/s
BenchmarkSum64/sz=16777216-32               1989            591216 ns/op        28377.47 MB/s
```

Add the benchmark above.