### PR TITLE
Remove NewReader error

### DIFF
--- a/_testref/ref_bench_test.go
+++ b/_testref/ref_bench_test.go
@@ -100,10 +100,7 @@ func BenchmarkAppendDecompress(b *testing.B) {
 			compressed := liteEncode(b, data, level)
 
 			b.Run(fmt.Sprintf("lite/level-%d/%s", level, name), func(b *testing.B) {
-				r, err := zstd.NewReader(bytes.NewReader([]byte{0x28, 0xb5, 0x2f, 0xfd, 0x04, 0x00, 0x01, 0x00, 0x00}))
-				if err != nil {
-					b.Fatal(err)
-				}
+				r := zstd.NewReader(bytes.NewReader([]byte{0x28, 0xb5, 0x2f, 0xfd, 0x04, 0x00, 0x01, 0x00, 0x00}))
 				defer r.Close()
 				buf := make([]byte, 0, len(data))
 				b.SetBytes(int64(len(data)))
@@ -140,10 +137,7 @@ func BenchmarkStreamDecode(b *testing.B) {
 			b.SetBytes(int64(len(medium)))
 			b.ResetTimer()
 			for range b.N {
-				r, err := zstd.NewReader(bytes.NewReader(compressed))
-				if err != nil {
-					b.Fatal(err)
-				}
+				r := zstd.NewReader(bytes.NewReader(compressed))
 				io.ReadAll(r)
 				r.Close()
 			}

--- a/_testref/ref_decode_test.go
+++ b/_testref/ref_decode_test.go
@@ -232,10 +232,7 @@ func TestRefLiteDecodeReset(t *testing.T) {
 	c1 := refEncode(t, src1)
 	c2 := refEncode(t, src2)
 
-	r, err := zstd.NewReader(bytes.NewReader(c1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(c1))
 	defer r.Close()
 	got1, err := readAll(r)
 	if err != nil {
@@ -261,13 +258,10 @@ func TestRefLiteDecodeMaxWindowSize(t *testing.T) {
 	compressed := refEncode(t, src, ref.WithWindowSize(8<<20))
 
 	// Try to decode with a small max window — should fail.
-	r, err := zstd.NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(compressed))
 	defer r.Close()
 	r.SetMaxWindowSize(1 << 10)
-	_, err = readAll(r)
+	_, err := readAll(r)
 	if err == nil {
 		t.Error("expected error for small max window size, got nil")
 	}

--- a/_testref/ref_dict_test.go
+++ b/_testref/ref_dict_test.go
@@ -59,10 +59,7 @@ func TestRefDictMarshalRoundTrip(t *testing.T) {
 	w.AddDict(liteDict)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := zstd.NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(compressed))
 	defer r.Close()
 	r.AddDict(&d2)
 	got, err := readAll(r)
@@ -98,10 +95,7 @@ func TestRefDictParsedParentEncodeLiteDecode(t *testing.T) {
 	for _, rl := range []ref.EncoderLevel{ref.SpeedFastest, ref.SpeedDefault, ref.SpeedBetterCompression, ref.SpeedBestCompression} {
 		compressed := refEncode(t, src, ref.WithEncoderLevel(rl), ref.WithEncoderDict(raw))
 
-		r, err := zstd.NewReader(bytes.NewReader(compressed))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r := zstd.NewReader(bytes.NewReader(compressed))
 		r.AddDict(liteDict)
 		got, err := readAll(r)
 		r.Close()
@@ -138,10 +132,7 @@ func TestRefDictRawParentEncodeLiteDecode(t *testing.T) {
 	for _, rl := range []ref.EncoderLevel{ref.SpeedFastest, ref.SpeedDefault, ref.SpeedBetterCompression, ref.SpeedBestCompression} {
 		compressed := refEncode(t, src, ref.WithEncoderLevel(rl), ref.WithEncoderDictRaw(0, rawDict))
 
-		r, err := zstd.NewReader(bytes.NewReader(compressed))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r := zstd.NewReader(bytes.NewReader(compressed))
 		r.SetRawDict(rawDict)
 		got, err := readAll(r)
 		r.Close()
@@ -169,13 +160,10 @@ func TestRefDictParsedAppendToBothDirs(t *testing.T) {
 
 	// parent → lite
 	compressed = refEncode(t, src, ref.WithEncoderDict(raw))
-	r, err := zstd.NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(compressed))
 	defer r.Close()
 	r.AddDict(liteDict)
-	got, err = readAll(r)
+	got, err := readAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,13 +187,10 @@ func TestRefDictRawAppendToBothDirs(t *testing.T) {
 
 	// parent → lite
 	compressed = refEncode(t, src, ref.WithEncoderDictRaw(0, rawDict))
-	r, err := zstd.NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(compressed))
 	defer r.Close()
 	r.SetRawDict(rawDict)
-	got, err = readAll(r)
+	got, err := readAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,13 +216,10 @@ func TestRefDictStreamBothDirs(t *testing.T) {
 
 	// parent stream → lite decode
 	compressed := refStreamEncode(t, src, ref.WithEncoderDict(raw))
-	r, err := zstd.NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(compressed))
 	defer r.Close()
 	r.AddDict(liteDict)
-	got, err = readAll(r)
+	got, err := readAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/_testref/ref_errors_test.go
+++ b/_testref/ref_errors_test.go
@@ -32,11 +32,9 @@ func TestRefCorruptDataBothReject(t *testing.T) {
 	bad[len(bad)/2] ^= 0xff
 
 	// Lite should error.
-	r, err := zstd.NewReader(bytes.NewReader(bad))
-	if err == nil {
-		_, err = io.ReadAll(r)
-		r.Close()
-	}
+	r := zstd.NewReader(bytes.NewReader(bad))
+	_, err := io.ReadAll(r)
+	r.Close()
 	liteErr := err != nil
 
 	// Parent should error.
@@ -59,11 +57,9 @@ func TestRefTruncatedStreamBothReject(t *testing.T) {
 	// Truncate to 75% of the compressed data.
 	trunc := compressed[:len(compressed)*3/4]
 
-	r, err := zstd.NewReader(bytes.NewReader(trunc))
-	if err == nil {
-		_, err = io.ReadAll(r)
-		r.Close()
-	}
+	r := zstd.NewReader(bytes.NewReader(trunc))
+	_, err := io.ReadAll(r)
+	r.Close()
 	liteErr := err != nil
 
 	dec, err := ref.NewReader(nil)
@@ -89,11 +85,9 @@ func TestRefBadChecksumBothReject(t *testing.T) {
 	copy(bad, compressed)
 	bad[len(bad)-1] ^= 0xff
 
-	r, err := zstd.NewReader(bytes.NewReader(bad))
-	if err == nil {
-		_, err = io.ReadAll(r)
-		r.Close()
-	}
+	r := zstd.NewReader(bytes.NewReader(bad))
+	_, err := io.ReadAll(r)
+	r.Close()
 	liteErr := err != nil
 
 	dec, err := ref.NewReader(nil)

--- a/_testref/ref_fuzz_test.go
+++ b/_testref/ref_fuzz_test.go
@@ -65,10 +65,7 @@ func FuzzRefDecoderCompat(f *testing.F) {
 		}
 		encs[i] = enc
 	}
-	liteDec, err := zstd.NewReader(nil)
-	if err != nil {
-		f.Fatal(err)
-	}
+	liteDec := zstd.NewReader(nil)
 
 	var compressed, got []byte
 	f.Fuzz(func(t *testing.T, data []byte, levelHint int) {
@@ -82,7 +79,7 @@ func FuzzRefDecoderCompat(f *testing.F) {
 		}
 
 		compressed = enc.EncodeAll(data, compressed[:0])
-		got, err = liteDec.AppendDecompress(got[:0], compressed)
+		got, err := liteDec.AppendDecompress(got[:0], compressed)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -106,10 +103,7 @@ func FuzzRefBothDecoders(f *testing.F) {
 	}
 	defer refDec.Close()
 
-	liteDec, err := zstd.NewReader(bytes.NewReader(nil))
-	if err != nil {
-		f.Fatal(err)
-	}
+	liteDec := zstd.NewReader(bytes.NewReader(nil))
 	liteDec.SetMaxWindowSize(maxWindow)
 	var refResult []byte
 	f.Fuzz(func(t *testing.T, data []byte) {
@@ -149,10 +143,7 @@ func FuzzRefRawDictCompat(f *testing.F) {
 		f.Fatal(err)
 	}
 	defer refEnc.Close()
-	dec, err := zstd.NewReader(nil)
-	if err != nil {
-		f.Fatal(err)
-	}
+	dec := zstd.NewReader(nil)
 	defer dec.Close()
 
 	f.Fuzz(func(t *testing.T, dictData, payload []byte) {
@@ -226,10 +217,7 @@ func FuzzRefDictCompat(f *testing.F) {
 	f.Add(dictFor(testData(1024)), testData(512))
 
 	w := zstd.NewWriter(nil)
-	dec, err := zstd.NewReader(nil)
-	if err != nil {
-		f.Fatal(err)
-	}
+	dec := zstd.NewReader(nil)
 	defer dec.Close()
 	refDec, err := ref.NewReader(nil)
 	if err != nil {

--- a/_testref/ref_test.go
+++ b/_testref/ref_test.go
@@ -74,10 +74,7 @@ func liteEncodeOpts(t testing.TB, src []byte, setup func(*zstd.Writer)) []byte {
 
 func liteDecode(t testing.TB, compressed []byte) []byte {
 	t.Helper()
-	r, err := zstd.NewReader(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := zstd.NewReader(nil)
 	got, err := r.AppendDecompress(nil, compressed)
 	if err != nil {
 		t.Fatal(err)
@@ -87,10 +84,7 @@ func liteDecode(t testing.TB, compressed []byte) []byte {
 
 func liteDecodeOpts(t testing.TB, compressed []byte, setup func(*zstd.Reader)) []byte {
 	t.Helper()
-	r, err := zstd.NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(compressed))
 	defer r.Close()
 	setup(r)
 	got, err := io.ReadAll(r)

--- a/bench_test.go
+++ b/bench_test.go
@@ -208,7 +208,7 @@ func BenchmarkAppendDecompress(b *testing.B) {
 		pcs := preCompress(benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				r, _ := NewReader(nil)
+				r := NewReader(nil)
 				var dst []byte
 				b.SetBytes(int64(len(pc.src)))
 				b.ReportAllocs()
@@ -226,7 +226,7 @@ func BenchmarkRead(b *testing.B) {
 		pcs := preCompress(benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				r, _ := NewReader(bytes.NewReader(pc.compressed))
+				r := NewReader(bytes.NewReader(pc.compressed))
 				b.SetBytes(int64(len(pc.src)))
 				b.ResetTimer()
 				for range b.N {
@@ -243,7 +243,7 @@ func BenchmarkWriteTo(b *testing.B) {
 		pcs := preCompress(benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				r, _ := NewReader(bytes.NewReader(pc.compressed))
+				r := NewReader(bytes.NewReader(pc.compressed))
 				b.SetBytes(int64(len(pc.src)))
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -300,7 +300,7 @@ func BenchmarkAppendDecompress_Dict(b *testing.B) {
 		compressed := w.AppendCompress(nil, src)
 
 		b.Run(lvl.name, func(b *testing.B) {
-			r, _ := NewReader(nil)
+			r := NewReader(nil)
 			r.SetRawDict(dict)
 			var dst []byte
 			b.SetBytes(int64(len(src)))
@@ -322,7 +322,7 @@ func BenchmarkNewWriter(b *testing.B) {
 
 func BenchmarkNewReader(b *testing.B) {
 	for range b.N {
-		_, _ = NewReader(nil)
+		_ = NewReader(nil)
 	}
 }
 
@@ -343,7 +343,7 @@ func BenchmarkReaderReuse(b *testing.B) {
 	src := bytes.Repeat([]byte("reuse bench "), 500)
 	w := NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
-	r, _ := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed))
 	b.SetBytes(int64(len(src)))
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/dict_test.go
+++ b/dict_test.go
@@ -67,10 +67,7 @@ func TestRawDictRoundTripAllLevels(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			r, err := NewReader(bytes.NewReader(buf.Bytes()))
-			if err != nil {
-				t.Fatal(err)
-			}
+			r := NewReader(bytes.NewReader(buf.Bytes()))
 			r.SetRawDict(dictContent)
 			got, err := io.ReadAll(r)
 			if err := r.Close(); err != nil {
@@ -100,10 +97,7 @@ func TestRawDictAppendTo(t *testing.T) {
 			w.SetRawDict(dictContent)
 			compressed := w.AppendCompress(nil, src)
 
-			r, err := NewReader(bytes.NewReader(compressed))
-			if err != nil {
-				t.Fatal(err)
-			}
+			r := NewReader(bytes.NewReader(compressed))
 			r.SetRawDict(dictContent)
 			got, err := io.ReadAll(r)
 			if err := r.Close(); err != nil {
@@ -147,10 +141,7 @@ func TestNoDictDecodeWithDict(t *testing.T) {
 	w := NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	r.SetRawDict(dictContent)
 	got, err := io.ReadAll(r)
 	if err := r.Close(); err != nil {
@@ -180,10 +171,7 @@ func TestDictNilClear(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -322,10 +310,7 @@ func TestParsedDictRoundTrip(t *testing.T) {
 			w.AddDict(d)
 			compressed := w.AppendCompress(nil, src)
 
-			r, err := NewReader(bytes.NewReader(compressed))
-			if err != nil {
-				t.Fatal(err)
-			}
+			r := NewReader(bytes.NewReader(compressed))
 			r.AddDict(d)
 			got, err := io.ReadAll(r)
 			if err := r.Close(); err != nil {
@@ -360,10 +345,7 @@ func TestParsedDictStreamRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	r.AddDict(d)
 	got, err := io.ReadAll(r)
 	_ = r.Close()
@@ -388,10 +370,7 @@ func TestParsedDictMultiBlock(t *testing.T) {
 	w.AddDict(d)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	r.AddDict(d)
 	got, err := io.ReadAll(r)
 	_ = r.Close()
@@ -415,10 +394,7 @@ func TestParsedDictAppendCompress(t *testing.T) {
 	w.AddDict(d)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(nil)
 	r.AddDict(d)
 	got, err := r.AppendDecompress(nil, compressed)
 	_ = r.Close()
@@ -443,10 +419,7 @@ func TestDictIDMismatch(t *testing.T) {
 	compressed := w.AppendCompress(nil, src)
 
 	// Decode without dict registered → ErrUnknownDictionary.
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	_, err = io.ReadAll(r)
 	_ = r.Close()
 	if err != ErrUnknownDictionary {
@@ -454,7 +427,7 @@ func TestDictIDMismatch(t *testing.T) {
 	}
 
 	// Also test DecodeBytes path.
-	r2, _ := NewReader(bytes.NewReader(nil))
+	r2 := NewReader(bytes.NewReader(nil))
 	_, err = r2.AppendDecompress(nil, compressed)
 	_ = r2.Close()
 	if err != ErrUnknownDictionary {
@@ -484,7 +457,7 @@ func TestDictIDFrameEncoding(t *testing.T) {
 			w.AddDict(d)
 			compressed := w.AppendCompress(nil, src)
 
-			r, _ := NewReader(bytes.NewReader(nil))
+			r := NewReader(bytes.NewReader(nil))
 			r.AddDict(d)
 			got, err := r.AppendDecompress(nil, compressed)
 			_ = r.Close()
@@ -530,7 +503,7 @@ func TestMultipleDictsRegistered(t *testing.T) {
 	// Concatenate two frames.
 	combined := append(compA, compB...)
 
-	r, _ := NewReader(bytes.NewReader(nil))
+	r := NewReader(bytes.NewReader(nil))
 	r.AddDict(dA)
 	r.AddDict(dB)
 	got, err := r.AppendDecompress(nil, combined)
@@ -600,7 +573,7 @@ func TestRawDictSmall(t *testing.T) {
 			w.SetRawDict(dictContent)
 			compressed := w.AppendCompress(nil, src)
 
-			r, _ := NewReader(bytes.NewReader(compressed))
+			r := NewReader(bytes.NewReader(compressed))
 			r.SetRawDict(dictContent)
 			got, err := io.ReadAll(r)
 			_ = r.Close()
@@ -634,7 +607,7 @@ func TestRawDictTooShortIgnored(t *testing.T) {
 	}
 
 	// Reader side: short dict should not register.
-	r, _ := NewReader(nil)
+	r := NewReader(nil)
 	r.SetRawDict(bytes.Repeat([]byte("x"), 3))
 	got, err := r.AppendDecompress(nil, want)
 	_ = r.Close()
@@ -662,7 +635,7 @@ func TestDictWriterReuseAcrossReset(t *testing.T) {
 			w.SetRawDict(dictContent)
 			compressed := w.AppendCompress(nil, frame.src)
 
-			r, _ := NewReader(bytes.NewReader(compressed))
+			r := NewReader(bytes.NewReader(compressed))
 			r.SetRawDict(dictContent)
 			got, err := io.ReadAll(r)
 			_ = r.Close()
@@ -688,10 +661,7 @@ func TestReaderAddDictNilClear(t *testing.T) {
 	w.AddDict(d)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	r.AddDict(d)
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -724,10 +694,7 @@ func TestReaderSetRawDictNilClear(t *testing.T) {
 	w.AddDict(d)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	r.AddDict(d)
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -767,10 +734,7 @@ func TestReaderNilClearMultipleDicts(t *testing.T) {
 	wRaw.SetRawDict(dictContent)
 	compRaw := wRaw.AppendCompress(nil, src)
 
-	r, err := NewReader(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(nil)
 	r.AddDict(d)
 	r.SetRawDict(dictContent)
 
@@ -821,10 +785,7 @@ func TestWriterSetRawDictNilClear(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -851,7 +812,7 @@ func TestDictReaderReuseAcrossReset(t *testing.T) {
 	comp1 := compress(src1)
 	comp2 := compress(src2)
 
-	r, _ := NewReader(bytes.NewReader(comp1))
+	r := NewReader(bytes.NewReader(comp1))
 	r.SetRawDict(dictContent)
 	got1, err := io.ReadAll(r)
 	if err != nil {
@@ -906,7 +867,7 @@ func TestReaderSetRawDictShortIsNoOp(t *testing.T) {
 	w.SetRawDict(dictContent)
 	compressed := w.AppendCompress(nil, src)
 
-	r, _ := NewReader(nil)
+	r := NewReader(nil)
 	r.SetRawDict(dictContent)
 
 	// Short dict should be a no-op — real dict stays.
@@ -930,7 +891,7 @@ func TestReaderSetRawDictExactly8(t *testing.T) {
 	w.SetRawDict(dict)
 	compressed := w.AppendCompress(nil, src)
 
-	r, _ := NewReader(nil)
+	r := NewReader(nil)
 	r.SetRawDict(dict)
 	got, err := r.AppendDecompress(nil, compressed)
 	r.Close()
@@ -974,7 +935,7 @@ func TestDictSwitchBetweenFrames(t *testing.T) {
 	frame2 := w2.AppendCompress(nil, src)
 
 	// Reader switches dicts between frames.
-	r, _ := NewReader(bytes.NewReader(frame1))
+	r := NewReader(bytes.NewReader(frame1))
 	r.SetRawDict(dict1)
 	got1, err := io.ReadAll(r)
 	if err != nil {

--- a/examples_test.go
+++ b/examples_test.go
@@ -22,10 +22,7 @@ func Example_writerReader() {
 		log.Fatal(err)
 	}
 
-	r, err := zstd.NewReader(&buf)
-	if err != nil {
-		log.Fatal(err)
-	}
+	r := zstd.NewReader(&buf)
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
 	}
@@ -40,10 +37,7 @@ func ExampleWriter_AppendCompress() {
 	w := zstd.NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := zstd.NewReader(bytes.NewReader(nil))
-	if err != nil {
-		log.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(nil))
 	defer r.Close()
 	decompressed, err := r.AppendDecompress(nil, compressed)
 	if err != nil {
@@ -60,10 +54,7 @@ func ExampleReader_AppendDecompress() {
 	w := zstd.NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := zstd.NewReader(bytes.NewReader(nil))
-	if err != nil {
-		log.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(nil))
 	defer r.Close()
 
 	prefix := []byte("data: ")
@@ -90,10 +81,7 @@ func ExampleWriter_SetLevel() {
 	fast := compress(zstd.BestSpeed)
 	best := compress(zstd.BestCompression)
 
-	r, err := zstd.NewReader(bytes.NewReader(nil))
-	if err != nil {
-		log.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(nil))
 	defer r.Close()
 
 	dec, err := r.AppendDecompress(nil, fast)
@@ -124,10 +112,7 @@ func Example_reset() {
 
 	var buf bytes.Buffer
 	w := zstd.NewWriter(&buf)
-	r, err := zstd.NewReader(&buf)
-	if err != nil {
-		log.Fatal(err)
-	}
+	r := zstd.NewReader(&buf)
 
 	for _, p := range proverbs {
 		buf.Reset()
@@ -174,10 +159,7 @@ func ExampleWriter_Flush() {
 		log.Fatal(err)
 	}
 
-	r, err := zstd.NewReader(&buf)
-	if err != nil {
-		log.Fatal(err)
-	}
+	r := zstd.NewReader(&buf)
 	defer r.Close()
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
@@ -198,10 +180,7 @@ func ExampleWriter_ReadFrom() {
 		log.Fatal(err)
 	}
 
-	r, err := zstd.NewReader(&buf)
-	if err != nil {
-		log.Fatal(err)
-	}
+	r := zstd.NewReader(&buf)
 	defer r.Close()
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
@@ -225,10 +204,7 @@ func ExampleWriter_SetRawDict() {
 	without := compressWithDict(nil)
 	with := compressWithDict(dict)
 
-	r, err := zstd.NewReader(bytes.NewReader(nil))
-	if err != nil {
-		log.Fatal(err)
-	}
+	r := zstd.NewReader(bytes.NewReader(nil))
 	defer r.Close()
 
 	dec, err := r.AppendDecompress(nil, without)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -17,7 +17,7 @@ func FuzzRoundTrip(f *testing.F) {
 	f.Add(bytes.Repeat([]byte("abcdef"), 1000))
 	f.Add(make([]byte, 65536))
 	w := NewWriter(nil)
-	r, _ := NewReader(bytes.NewReader(nil))
+	r := NewReader(bytes.NewReader(nil))
 	var compressed []byte
 
 	f.Fuzz(func(t *testing.T, data []byte) {
@@ -87,10 +87,7 @@ func FuzzNewReader(f *testing.F) {
 	f.Add(w.AppendCompress(nil, bytes.Repeat([]byte{0}, 100000)))
 	f.Add(w.AppendCompress(nil, []byte{}))
 	f.Add([]byte{0x28, 0xb5, 0x2f, 0xfd}) // just magic
-	r, err := NewReader(nil)
-	if err != nil {
-		f.Fatal(err)
-	}
+	r := NewReader(nil)
 	// Cap window to prevent OOM on crafted frames.
 	if err := r.SetMaxWindowSize(1 << 20); err != nil {
 		f.Fatal(err)
@@ -99,7 +96,7 @@ func FuzzNewReader(f *testing.F) {
 	var dst []byte
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		err = r.Reset(bytes.NewReader(data))
+		err := r.Reset(bytes.NewReader(data))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -124,7 +121,7 @@ func FuzzStreamRoundTrip(f *testing.F) {
 	f.Add([]byte{9, 5}, bytes.Repeat([]byte("abcdef"), 1000))
 	f.Add([]byte{0x85, 0xff}, make([]byte, 65536))
 	w := NewWriter(nil)
-	r, _ := NewReader(bytes.NewReader(nil))
+	r := NewReader(bytes.NewReader(nil))
 
 	f.Fuzz(func(t *testing.T, cfg, data []byte) {
 		if len(cfg) != 2 {
@@ -199,7 +196,7 @@ func FuzzDictRoundTrip(f *testing.F) {
 	f.Add([]byte{0, 0}, []byte("small"))
 	f.Add([]byte{0, 0}, []byte("smallsmallsmallsmallsmall"))
 	w := NewWriter(nil)
-	r, _ := NewReader(bytes.NewReader(nil))
+	r := NewReader(bytes.NewReader(nil))
 
 	f.Fuzz(func(t *testing.T, cfg, data []byte) {
 		if len(cfg) < 2 || len(data) < 2 {
@@ -269,7 +266,7 @@ func FuzzReaderReset(f *testing.F) {
 	f.Add(byte(0), []byte{})
 	f.Add(byte(9), bytes.Repeat([]byte("reset"), 500))
 	w := NewWriter(nil)
-	r, _ := NewReader(bytes.NewReader(nil))
+	r := NewReader(bytes.NewReader(nil))
 	var buf bytes.Buffer
 
 	f.Fuzz(func(t *testing.T, levelByte byte, data []byte) {

--- a/reader.go
+++ b/reader.go
@@ -61,13 +61,13 @@ func (z *Reader) ensureInit() {
 // NewReader creates a new Reader reading from r.
 // If r is nil, the Reader may only be used with [Reader.AppendDecompress];
 // call [Reader.Reset] before streaming.
-func NewReader(r io.Reader) (*Reader, error) {
+func NewReader(r io.Reader) *Reader {
 	z := &Reader{}
 	z.ensureInit()
 	if r != nil {
 		z.rw.r = r
 	}
-	return z, nil
+	return z
 }
 
 // Reset discards the Reader's state and makes it read from r.

--- a/reader_test.go
+++ b/reader_test.go
@@ -59,10 +59,7 @@ func newXXHash(data []byte) uint64 {
 
 func TestReadRawBlock(t *testing.T) {
 	frame := buildRawFrame([]byte("hello"))
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -83,10 +80,7 @@ func TestReadRLEBlock(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, 'A') // repeated byte
 
-	r, err := NewReader(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -114,10 +108,7 @@ func TestReadCompressedRawLiterals(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, compData...)
 
-	r, err := NewReader(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -144,10 +135,7 @@ func TestReadCompressedRLELiterals(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, compData...)
 
-	r, err := NewReader(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -174,10 +162,7 @@ func TestReadMultiBlock(t *testing.T) {
 	buf = append(buf, byte(bh2), byte(bh2>>8), byte(bh2>>16))
 	buf = append(buf, 'd', 'e')
 
-	r, err := NewReader(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -193,10 +178,7 @@ func TestReadMultiFrame(t *testing.T) {
 	frame2 := buildRawFrame([]byte("lo"))
 	data := append(frame1, frame2...)
 
-	r, err := NewReader(bytes.NewReader(data))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(data))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -209,10 +191,7 @@ func TestReadMultiFrame(t *testing.T) {
 
 func TestReadChecksum(t *testing.T) {
 	frame := buildRawFrameChecksum([]byte("abc"))
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -227,12 +206,9 @@ func TestReadBadChecksum(t *testing.T) {
 	frame := buildRawFrameChecksum([]byte("abc"))
 	// Corrupt the checksum (last 4 bytes)
 	frame[len(frame)-1] ^= 0xFF
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer func() { _ = r.Close() }()
-	_, err = io.ReadAll(r)
+	_, err := io.ReadAll(r)
 	if !errors.Is(err, &ErrCorrupted{}) {
 		t.Fatalf("expected ErrCorrupted, got %v", err)
 	}
@@ -248,36 +224,27 @@ func TestReadFrameSizeMismatch(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, 'a', 'b', 'c')
 
-	r, err := NewReader(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf))
 	defer func() { _ = r.Close() }()
-	_, err = io.ReadAll(r)
+	_, err := io.ReadAll(r)
 	if !errors.Is(err, &ErrCorrupted{}) {
 		t.Fatalf("expected ErrCorrupted, got %v", err)
 	}
 }
 
 func TestReadMagicMismatch(t *testing.T) {
-	r, err := NewReader(bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}))
 	defer func() { _ = r.Close() }()
-	_, err = io.ReadAll(r)
+	_, err := io.ReadAll(r)
 	if !errors.Is(err, &ErrCorrupted{}) {
 		t.Fatalf("expected ErrCorrupted, got %v", err)
 	}
 }
 
 func TestReadEmpty(t *testing.T) {
-	r, err := NewReader(bytes.NewReader(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(nil))
 	defer func() { _ = r.Close() }()
-	_, err = io.ReadAll(r)
+	_, err := io.ReadAll(r)
 	if !errors.Is(err, &ErrCorrupted{}) {
 		t.Fatalf("expected ErrCorrupted, got %v", err)
 	}
@@ -294,10 +261,7 @@ func TestReadEmptyFrame(t *testing.T) {
 	// Block: last=1, raw, size=0
 	buf = append(buf, 0x01, 0x00, 0x00)
 
-	r, err := NewReader(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -317,10 +281,7 @@ func TestReadSkippableFrame(t *testing.T) {
 	// Real frame
 	buf = append(buf, buildRawFrame([]byte("hi"))...)
 
-	r, err := NewReader(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -333,10 +294,7 @@ func TestReadSkippableFrame(t *testing.T) {
 
 func TestReadSmallBuffer(t *testing.T) {
 	frame := buildRawFrame([]byte("hello world"))
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer func() { _ = r.Close() }()
 
 	// Read one byte at a time
@@ -363,10 +321,7 @@ func TestReadReset(t *testing.T) {
 	frame1 := buildRawFrame([]byte("first"))
 	frame2 := buildRawFrame([]byte("second"))
 
-	r, err := NewReader(bytes.NewReader(frame1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame1))
 	defer func() { _ = r.Close() }()
 
 	got1, err := io.ReadAll(r)
@@ -391,12 +346,9 @@ func TestReadReset(t *testing.T) {
 
 func TestReadAfterClose(t *testing.T) {
 	frame := buildRawFrame([]byte("test"))
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	_ = r.Close()
-	_, err = r.Read(make([]byte, 10))
+	_, err := r.Read(make([]byte, 10))
 	if err != ErrDecoderClosed {
 		t.Fatalf("expected ErrDecoderClosed, got %v", err)
 	}
@@ -412,10 +364,7 @@ func TestReadWindowedFrame(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, 'h', 'e', 'l', 'l', 'o')
 
-	r, err := NewReader(bytes.NewReader(buf))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -427,10 +376,7 @@ func TestReadWindowedFrame(t *testing.T) {
 }
 
 func TestNewReaderNilInput(t *testing.T) {
-	r, err := NewReader(nil)
-	if err != nil {
-		t.Fatalf("NewReader(nil) returned error: %v", err)
-	}
+	r := NewReader(nil)
 	frame := buildRawFrame([]byte("after nil"))
 	if err := r.Reset(bytes.NewReader(frame)); err != nil {
 		t.Fatal(err)
@@ -446,14 +392,11 @@ func TestNewReaderNilInput(t *testing.T) {
 }
 
 func TestReaderResetNilClosesReader(t *testing.T) {
-	r, err := NewReader(bytes.NewReader(buildRawFrame([]byte("x"))))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buildRawFrame([]byte("x"))))
 	if err := r.Reset(nil); err != nil {
 		t.Fatal(err)
 	}
-	_, err = r.Read(make([]byte, 1))
+	_, err := r.Read(make([]byte, 1))
 	if err != ErrDecoderClosed {
 		t.Fatalf("expected ErrDecoderClosed after Reset(nil), got %v", err)
 	}
@@ -461,10 +404,7 @@ func TestReaderResetNilClosesReader(t *testing.T) {
 
 func TestWriteToBasic(t *testing.T) {
 	frame := buildRawFrame([]byte("hello"))
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -477,13 +417,10 @@ func TestWriteToBasic(t *testing.T) {
 }
 
 func TestWriteToEmpty(t *testing.T) {
-	r, err := NewReader(bytes.NewReader(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(nil))
 	defer r.Close()
 	var buf bytes.Buffer
-	_, err = r.WriteTo(&buf)
+	_, err := r.WriteTo(&buf)
 	if !errors.Is(err, &ErrCorrupted{}) {
 		t.Fatalf("expected ErrCorrupted, got %v", err)
 	}
@@ -499,10 +436,7 @@ func TestWriteToEmptyFrame(t *testing.T) {
 	frame = append(frame, 0x00)
 	frame = append(frame, 0x01, 0x00, 0x00)
 
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -526,10 +460,7 @@ func TestWriteToMultiBlock(t *testing.T) {
 	frame = append(frame, byte(bh2), byte(bh2>>8), byte(bh2>>16))
 	frame = append(frame, 'd', 'e')
 
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -543,10 +474,7 @@ func TestWriteToMultiBlock(t *testing.T) {
 
 func TestWriteToMultiFrame(t *testing.T) {
 	data := append(buildRawFrame([]byte("hi")), buildRawFrame([]byte("lo"))...)
-	r, err := NewReader(bytes.NewReader(data))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(data))
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -560,10 +488,7 @@ func TestWriteToMultiFrame(t *testing.T) {
 
 func TestWriteToChecksum(t *testing.T) {
 	frame := buildRawFrameChecksum([]byte("abc"))
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -578,13 +503,10 @@ func TestWriteToChecksum(t *testing.T) {
 func TestWriteToBadChecksum(t *testing.T) {
 	frame := buildRawFrameChecksum([]byte("abc"))
 	frame[len(frame)-1] ^= 0xFF
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer r.Close()
 	var buf bytes.Buffer
-	_, err = r.WriteTo(&buf)
+	_, err := r.WriteTo(&buf)
 	if !errors.Is(err, &ErrCorrupted{}) {
 		t.Fatalf("expected ErrCorrupted, got %v", err)
 	}
@@ -599,25 +521,19 @@ func TestWriteToFrameSizeMismatch(t *testing.T) {
 	frame = append(frame, byte(bh), byte(bh>>8), byte(bh>>16))
 	frame = append(frame, 'a', 'b', 'c') // only 3 bytes
 
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer r.Close()
 	var buf bytes.Buffer
-	_, err = r.WriteTo(&buf)
+	_, err := r.WriteTo(&buf)
 	if !errors.Is(err, &ErrCorrupted{}) {
 		t.Fatalf("expected ErrCorrupted, got %v", err)
 	}
 }
 
 func TestWriteToAfterClose(t *testing.T) {
-	r, err := NewReader(bytes.NewReader(buildRawFrame([]byte("test"))))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buildRawFrame([]byte("test"))))
 	r.Close()
-	_, err = r.WriteTo(&bytes.Buffer{})
+	_, err := r.WriteTo(&bytes.Buffer{})
 	if err != ErrDecoderClosed {
 		t.Fatalf("expected ErrDecoderClosed, got %v", err)
 	}
@@ -625,10 +541,7 @@ func TestWriteToAfterClose(t *testing.T) {
 
 func TestWriteToAfterPartialRead(t *testing.T) {
 	frame := buildRawFrame([]byte("hello world"))
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer r.Close()
 
 	// Read only 5 bytes.
@@ -668,15 +581,12 @@ func (w *errWriter) Write(p []byte) (int, error) {
 
 func TestWriteToWriteError(t *testing.T) {
 	frame := buildRawFrame([]byte("hello world"))
-	r, err := NewReader(bytes.NewReader(frame))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame))
 	defer r.Close()
 
 	writeErr := errors.New("disk full")
 	ew := &errWriter{n: 0, err: writeErr}
-	_, err = r.WriteTo(ew)
+	_, err := r.WriteTo(ew)
 	if err != writeErr {
 		t.Fatalf("expected writeErr, got %v", err)
 	}
@@ -698,13 +608,10 @@ func TestWriteToCompressed(t *testing.T) {
 			}
 			compressed := w.AppendCompress(nil, src)
 
-			r, err := NewReader(bytes.NewReader(compressed))
-			if err != nil {
-				t.Fatal(err)
-			}
+			r := NewReader(bytes.NewReader(compressed))
 			defer r.Close()
 			var buf bytes.Buffer
-			_, err = r.WriteTo(&buf)
+			_, err := r.WriteTo(&buf)
 			if err != nil {
 				t.Fatalf("level %d: %v", level, err)
 			}
@@ -723,10 +630,7 @@ func TestWriteToLarge(t *testing.T) {
 	w := NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -752,14 +656,11 @@ func TestWriteToDict(t *testing.T) {
 		w.SetRawDict(dictContent)
 		compressed := w.AppendCompress(nil, src)
 
-		r, err := NewReader(bytes.NewReader(compressed))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r := NewReader(bytes.NewReader(compressed))
 		defer r.Close()
 		r.SetRawDict(dictContent)
 		var buf bytes.Buffer
-		_, err = r.WriteTo(&buf)
+		_, err := r.WriteTo(&buf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -781,10 +682,7 @@ func TestWriteToDict(t *testing.T) {
 		w.AddDict(d)
 		compressed := w.AppendCompress(nil, src)
 
-		r, err := NewReader(bytes.NewReader(compressed))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r := NewReader(bytes.NewReader(compressed))
 		defer r.Close()
 		r.AddDict(d)
 		var buf bytes.Buffer
@@ -802,10 +700,7 @@ func TestReaderReuseAfterClose(t *testing.T) {
 	frame1 := buildRawFrame([]byte("before"))
 	frame2 := buildRawFrame([]byte("after"))
 
-	r, err := NewReader(bytes.NewReader(frame1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame1))
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -832,10 +727,7 @@ func TestReaderReuseAfterCloseWriteTo(t *testing.T) {
 	frame1 := buildRawFrame([]byte("before"))
 	frame2 := buildRawFrame([]byte("after"))
 
-	r, err := NewReader(bytes.NewReader(frame1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame1))
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -863,10 +755,7 @@ func TestReaderReuseAfterCloseAppendCompress(t *testing.T) {
 	frame1 := buildRawFrame([]byte("before"))
 	frame2 := buildRawFrame([]byte("after"))
 
-	r, err := NewReader(bytes.NewReader(frame1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(frame1))
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -890,10 +779,7 @@ func TestReaderReuseAfterCloseAppendCompress(t *testing.T) {
 }
 
 func TestReaderReuseAfterCloseMultiple(t *testing.T) {
-	r, err := NewReader(bytes.NewReader(buildRawFrame([]byte("init"))))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buildRawFrame([]byte("init"))))
 
 	for i := range 5 {
 		want := []byte{byte('A' + i), byte('0' + i)}
@@ -924,10 +810,7 @@ func TestWriteToMatchesReadAll(t *testing.T) {
 		compressed := w.AppendCompress(nil, src)
 
 		// ReadAll
-		r1, err := NewReader(bytes.NewReader(compressed))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r1 := NewReader(bytes.NewReader(compressed))
 		readResult, err := io.ReadAll(r1)
 		r1.Close()
 		if err != nil {
@@ -935,10 +818,7 @@ func TestWriteToMatchesReadAll(t *testing.T) {
 		}
 
 		// WriteTo
-		r2, err := NewReader(bytes.NewReader(compressed))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r2 := NewReader(bytes.NewReader(compressed))
 		var buf bytes.Buffer
 		_, err = r2.WriteTo(&buf)
 		r2.Close()
@@ -961,10 +841,7 @@ func TestWriteToSkippableFrame(t *testing.T) {
 	// Real frame
 	data = append(data, buildRawFrame([]byte("hi"))...)
 
-	r, err := NewReader(bytes.NewReader(data))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(data))
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -1010,10 +887,7 @@ func TestAppendDecompressConcurrent(t *testing.T) {
 	w := NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(nil)
 
 	const goroutines = 8
 	var wg sync.WaitGroup
@@ -1060,7 +934,7 @@ func TestSetMaxWindowSize(t *testing.T) {
 	compressed := w.AppendCompress(nil, src)
 
 	// Decoding with a tiny max window should fail.
-	r, _ := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed))
 	if err := r.SetMaxWindowSize(MinWindowSize); err != nil {
 		t.Fatal(err)
 	}
@@ -1080,7 +954,7 @@ func TestSetMaxWindowSizeMax(t *testing.T) {
 	w := NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
 
-	r, _ := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed))
 	if err := r.SetMaxWindowSize(MaxWindowSize); err != nil {
 		t.Fatal(err)
 	}
@@ -1095,7 +969,7 @@ func TestSetMaxWindowSizeMax(t *testing.T) {
 }
 
 func TestSetMaxWindowSizeValidation(t *testing.T) {
-	r, _ := NewReader(nil)
+	r := NewReader(nil)
 	if err := r.SetMaxWindowSize(0); err == nil {
 		t.Fatal("expected error for 0")
 	}
@@ -1122,7 +996,7 @@ func TestReadTruncatedBlockHeader(t *testing.T) {
 	buf = append(buf, 0x05)
 	buf = append(buf, 0x01, 0x00) // only 2 bytes of block header
 
-	r, _ := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf))
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1140,7 +1014,7 @@ func TestReadTruncatedBlockData(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, 'a', 'b') // only 2 of 5 bytes
 
-	r, _ := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf))
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1157,7 +1031,7 @@ func TestReadReservedBlockType(t *testing.T) {
 	bh := uint32(1) | (3 << 1) | (0 << 3)
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 
-	r, _ := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf))
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1178,7 +1052,7 @@ func TestReadWindowSizeTooSmall(t *testing.T) {
 	bh := uint32(1) | (0 << 1) | (0 << 3)
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 
-	r, _ := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1195,7 +1069,7 @@ func TestReadReservedFrameHeaderBit(t *testing.T) {
 	// FHD with reserved bit 3 set.
 	buf = append(buf, 0x08)
 
-	r, _ := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf))
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1227,7 +1101,7 @@ func TestReadIOError(t *testing.T) {
 
 	// Truncate so the reader fails mid-block.
 	er := &errReader{data: frame[:len(frame)-5], err: readErr}
-	r, _ := NewReader(er)
+	r := NewReader(er)
 	_, err := io.ReadAll(r)
 	r.Close()
 	if err == nil {
@@ -1250,7 +1124,7 @@ func TestReadMultipleSkippableFrames(t *testing.T) {
 	}
 	buf = append(buf, buildRawFrame([]byte("ok"))...)
 
-	r, _ := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1267,7 +1141,7 @@ func TestReadOnlySkippableFrames(t *testing.T) {
 	buf = append(buf, 0x01, 0x00, 0x00, 0x00)
 	buf = append(buf, 0xFF)
 
-	r, _ := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf))
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1282,7 +1156,7 @@ func TestReadSkippableFrameTypes(t *testing.T) {
 		buf = append(buf, 0x00, 0x00, 0x00, 0x00) // 0 bytes to skip
 		buf = append(buf, buildRawFrame([]byte("x"))...)
 
-		r, _ := NewReader(bytes.NewReader(buf))
+		r := NewReader(bytes.NewReader(buf))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -1312,7 +1186,7 @@ func TestAppendDecompressPreExistingDst(t *testing.T) {
 
 func TestAppendDecompressConcurrentDifferentData(t *testing.T) {
 	w := NewWriter(nil)
-	r, _ := NewReader(nil)
+	r := NewReader(nil)
 
 	const goroutines = 8
 	var wg sync.WaitGroup
@@ -1388,7 +1262,7 @@ func TestWriteToCompressedMultiBlock(t *testing.T) {
 		_ = w.SetLevel(level)
 		compressed := w.AppendCompress(nil, src)
 
-		r, _ := NewReader(bytes.NewReader(compressed))
+		r := NewReader(bytes.NewReader(compressed))
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
 		r.Close()
@@ -1410,7 +1284,7 @@ func TestWriteToPartialWriteError(t *testing.T) {
 	compressed := w.AppendCompress(nil, src)
 
 	writeErr := errors.New("out of space")
-	r, _ := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed))
 	// Accept 0 bytes — fail immediately.
 	ew := &errWriter{n: 0, err: writeErr}
 	_, err := r.WriteTo(ew)

--- a/writer_test.go
+++ b/writer_test.go
@@ -25,10 +25,7 @@ func roundTrip(t *testing.T, src []byte) {
 		t.Fatal("close:", err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal("new reader:", err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -48,10 +45,7 @@ func TestWriterEmpty(t *testing.T) {
 	if buf.Len() == 0 {
 		t.Fatal("expected non-empty frame for empty input")
 	}
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -132,10 +126,7 @@ func TestWriterMultipleSmallWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -172,10 +163,7 @@ func TestWriterFlush(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -212,10 +200,7 @@ func TestWriterReset(t *testing.T) {
 		{buf1.Bytes(), src1},
 		{buf2.Bytes(), src2},
 	} {
-		r, err := NewReader(bytes.NewReader(tc.compressed))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r := NewReader(bytes.NewReader(tc.compressed))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -291,10 +276,7 @@ func TestNoCompressionIsRaw(t *testing.T) {
 	if buf.Len() < len(src) {
 		t.Errorf("NoCompression reduced size: src=%d compressed=%d", len(src), buf.Len())
 	}
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -314,10 +296,7 @@ func TestNoCompressionIsRaw(t *testing.T) {
 	if len(compressed) < len(src) {
 		t.Errorf("AppendCompress NoCompression reduced size: src=%d compressed=%d", len(src), len(compressed))
 	}
-	r2, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r2 := NewReader(bytes.NewReader(compressed))
 	defer r2.Close()
 	got2, err := io.ReadAll(r2)
 	if err != nil {
@@ -333,10 +312,7 @@ func TestWriterAppendCompress(t *testing.T) {
 	w := NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -357,10 +333,7 @@ func TestWriterAppendCompressEmpty(t *testing.T) {
 	if !bytes.Equal(c1, c2) {
 		t.Fatal("nil and empty should produce identical frames")
 	}
-	r, err := NewReader(bytes.NewReader(c1))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(c1))
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -379,10 +352,7 @@ func TestWriterAppendCompressMultiBlock(t *testing.T) {
 	w := NewWriter(nil)
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -409,10 +379,7 @@ func TestWriterReadFrom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -433,10 +400,7 @@ func TestWriterCRCEnabled(t *testing.T) {
 	}
 
 	// Verify readable (CRC checked by reader).
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -458,10 +422,7 @@ func TestWriterNoCRC(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -505,10 +466,7 @@ func TestWriterSingleByteWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -531,10 +489,7 @@ func TestWriterSmallBuffer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 
 	// Read in small chunks.
@@ -570,10 +525,7 @@ func roundTripLevel(t *testing.T, src []byte, level int) {
 		t.Fatal("close:", err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal("new reader:", err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -670,10 +622,7 @@ func TestAppendCompressAllLevels(t *testing.T) {
 				t.Fatal(err)
 			}
 			compressed := w.AppendCompress(nil, src)
-			r, err := NewReader(bytes.NewReader(compressed))
-			if err != nil {
-				t.Fatal(err)
-			}
+			r := NewReader(bytes.NewReader(compressed))
 			defer func() { _ = r.Close() }()
 			got, err := io.ReadAll(r)
 			if err != nil {
@@ -698,10 +647,7 @@ func TestLevelSwitching(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r, err := NewReader(bytes.NewReader(buf.Bytes()))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r := NewReader(bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -718,10 +664,7 @@ func TestZeroValueWriter(t *testing.T) {
 	var w Writer
 	compressed := w.AppendCompress(nil, src)
 
-	r, err := NewReader(bytes.NewReader(compressed))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed))
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -744,10 +687,7 @@ func TestZeroValueWriterStream(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -787,11 +727,7 @@ func TestAppendCompressConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			compressed := w.AppendCompress(nil, src)
-			r, err := NewReader(bytes.NewReader(compressed))
-			if err != nil {
-				errs <- err
-				return
-			}
+			r := NewReader(bytes.NewReader(compressed))
 			defer r.Close()
 			got, err := io.ReadAll(r)
 			if err != nil {
@@ -891,7 +827,7 @@ func TestResetContentSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -914,7 +850,7 @@ func TestResetContentSizeNegative(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1075,7 +1011,7 @@ func TestFlushMultiple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1100,7 +1036,7 @@ func TestReadFromEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1157,7 +1093,7 @@ func TestReadFromLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -29,10 +29,7 @@ func TestRoundTripStreaming(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	// Read one byte at a time.
 	var got []byte
 	tmp := make([]byte, 1)
@@ -71,10 +68,7 @@ func TestRoundTripLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -91,10 +85,7 @@ func TestConcatenatedFrames(t *testing.T) {
 	frame2 := w.AppendCompress(nil, []byte("frame two"))
 
 	combined := append(frame1, frame2...)
-	r, err := NewReader(bytes.NewReader(combined))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(combined))
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -121,10 +112,7 @@ func TestIOCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := NewReader(bytes.NewReader(compressed.Bytes()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	r := NewReader(bytes.NewReader(compressed.Bytes()))
 	var decompressed bytes.Buffer
 	_, err = io.Copy(&decompressed, r)
 	_ = r.Close()
@@ -150,10 +138,7 @@ func TestResetCycles(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r, err := NewReader(bytes.NewReader(buf.Bytes()))
-		if err != nil {
-			t.Fatal(err)
-		}
+		r := NewReader(bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -199,10 +184,7 @@ func TestAllLevelsRoundTrip(t *testing.T) {
 				}
 				compressed := w.AppendCompress(nil, input.data)
 
-				r, err := NewReader(bytes.NewReader(compressed))
-				if err != nil {
-					t.Fatal(err)
-				}
+				r := NewReader(bytes.NewReader(compressed))
 				got, err := io.ReadAll(r)
 				_ = r.Close()
 				if err != nil {
@@ -292,11 +274,7 @@ func TestConcurrentReadersFromSameFrame(t *testing.T) {
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			r, err := NewReader(bytes.NewReader(compressed))
-			if err != nil {
-				errs <- err
-				return
-			}
+			r := NewReader(bytes.NewReader(compressed))
 			got, err := io.ReadAll(r)
 			r.Close()
 			if err != nil {
@@ -324,7 +302,7 @@ func TestAppendConcurrentBidirectional(t *testing.T) {
 	}
 
 	w := NewWriter(nil)
-	r, _ := NewReader(nil)
+	r := NewReader(nil)
 
 	// Pre-compress all inputs.
 	compressed := make([][]byte, len(inputs))
@@ -429,7 +407,7 @@ func TestZeroValueWriterReset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -456,7 +434,7 @@ func TestZeroValueWriterReadFrom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, _ := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {


### PR DESCRIPTION
It is pointless since no params are given and we don't start decoding anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified reader creation: `NewReader` now returns a reader directly, making setup code easier to use.
* **Bug Fixes**
  * Updated decoding, streaming, benchmark, fuzz, and example paths to work with the new reader construction flow.
  * Removed unnecessary startup error checks in tests and helpers, reducing boilerplate without changing decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->