### PR TITLE
writer: return encoder to pool on Close to avoid allocation leak

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -373,6 +373,10 @@ func (w *Writer) Close() error {
 	if w.enc == nil {
 		return nil
 	}
+	defer func() {
+		putEncoder(w.enc)
+		w.enc = nil
+	}()
 	err := w.nextBlock(true)
 	if err != nil {
 		return err


### PR DESCRIPTION
The fix prevents unnecessary memory allocations by returning the encoder to the sync.Pool when a stream is closed, while setting the internal reference to nil to safely support subsequent double-closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup when closing a writer, including when an error occurs while finalizing output.
  * Prevented encoder resources from remaining allocated after close operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->