### PR TITLE
Use functional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,42 +58,48 @@ Bytes interface:
 
 ## Configuration split: Encoder / Decoder
 
-Configuration and the one-shot byte operations live on two config types, so a
-stream's settings can be prepared and reused independently of any single stream:
+Configuration is supplied through functional options that are shared by each
+side's constructors: the same `EncoderOption` values configure `NewEncoder`
+(one-shot) and `NewWriter` (streaming); likewise `DecoderOption` for
+`NewDecoder` and `NewReader`. Configuration is fixed at construction and
+immutable afterwards.
 
 ```go
 type Encoder struct{ /* no exported fields */ }
-func NewEncoder() *Encoder
-func (*Encoder) SetLevel(int) error
-func (*Encoder) SetWindowSize(int) error
-func (*Encoder) SetLowMemory(bool)
-func (*Encoder) SetCRC(bool)
-func (*Encoder) AddDict(*Dict)
-func (*Encoder) SetRawDict([]byte)
+type EncoderOption func(*Encoder) error
+func NewEncoder(opts ...EncoderOption) (*Encoder, error)
+func WithEncoderLevel(int) EncoderOption
+func WithWindowSize(int) EncoderOption
+func WithLowMemory(bool) EncoderOption
+func WithEncoderCRC(bool) EncoderOption
+func WithEncoderDict(*Dict) EncoderOption
+func WithEncoderRawDict([]byte) EncoderOption
 func (*Encoder) AppendCompress(dst, src []byte) []byte
 
 type Decoder struct{ /* no exported fields */ }
-func NewDecoder() *Decoder
-func (*Decoder) SetMaxSize(int64) error       // total decompressed-output cap; 0 = unlimited
-func (*Decoder) SetMaxWindowSize(int) error
-func (*Decoder) AddDict(*Dict)
-func (*Decoder) SetRawDict([]byte)
+type DecoderOption func(*Decoder) error
+func NewDecoder(opts ...DecoderOption) (*Decoder, error)
+func WithDecoderMaxSize(int64) DecoderOption    // total decompressed-output cap; 0 = unlimited
+func WithDecoderMaxWindow(int) DecoderOption
+func WithDecoderDict(*Dict) DecoderOption
+func WithDecoderRawDict([]byte) DecoderOption
 func (*Decoder) AppendDecompress(dst, src []byte) ([]byte, error)
 ```
 
-The streaming `Writer`/`Reader` are bound to a config object; a nil argument
-uses default configuration:
+The streaming `Writer`/`Reader` take the same options; with no options they use
+default configuration:
 
 ```go
-func NewWriter(w io.Writer, e *Encoder) *Writer
-func NewReader(r io.Reader, d *Decoder) *Reader
+func NewWriter(w io.Writer, opts ...EncoderOption) (*Writer, error)
+func NewReader(r io.Reader, opts ...DecoderOption) (*Reader, error)
 ```
 
-One `Encoder`/`Decoder` may configure many `Writer`/`Reader` values. It must not
-be reconfigured while a bound `Writer`/`Reader` is mid-stream; reconfigure
-between streams (before the first write, or after `Close`, then `Reset`).
+Options are applied in order, so a later option overrides an earlier one (e.g.
+`WithWindowSize` after `WithEncoderLevel`). To use different settings, construct
+a new `Encoder`/`Writer` (or `Decoder`/`Reader`); `Reset` swaps the
+destination/source and preserves the configuration.
 
-`(*Decoder).SetMaxSize(n)` caps the total number of decompressed bytes as a
+`WithDecoderMaxSize(n)` caps the total number of decompressed bytes as a
 decompression-bomb guard. The default, 0, disables the limit.
 
 # Pre-PR

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Bytes interface:
 Configuration is supplied through functional options that are shared by each
 side's constructors: the same `EncoderOption` values configure `NewEncoder`
 (one-shot) and `NewWriter` (streaming); likewise `DecoderOption` for
-`NewDecoder` and `NewReader`. Configuration is fixed at construction and
-immutable afterwards.
+`NewDecoder` and `NewReader`. The one-shot `Encoder`/`Decoder` types are
+immutable after construction; the streaming `Writer`/`Reader` can be
+reconfigured on `Reset` (see below).
 
 ```go
 type Encoder struct{ /* no exported fields */ }
@@ -74,6 +75,7 @@ func WithLowMemory(bool) EncoderOption
 func WithEncoderCRC(bool) EncoderOption
 func WithEncoderDict(*Dict) EncoderOption
 func WithEncoderRawDict([]byte) EncoderOption
+func WithContentSize(int64) EncoderOption       // streaming Writer only; declares total size
 func (*Encoder) AppendCompress(dst, src []byte) []byte
 
 type Decoder struct{ /* no exported fields */ }
@@ -92,12 +94,17 @@ default configuration:
 ```go
 func NewWriter(w io.Writer, opts ...EncoderOption) (*Writer, error)
 func NewReader(r io.Reader, opts ...DecoderOption) (*Reader, error)
+func (*Writer) Reset(w io.Writer, opts ...EncoderOption) error
+func (*Reader) Reset(r io.Reader, opts ...DecoderOption) error
 ```
 
 Options are applied in order, so a later option overrides an earlier one (e.g.
-`WithWindowSize` after `WithEncoderLevel`). To use different settings, construct
-a new `Encoder`/`Writer` (or `Decoder`/`Reader`); `Reset` swaps the
-destination/source and preserves the configuration.
+`WithWindowSize` after `WithEncoderLevel`).
+
+`Reset` reuses a `Writer`/`Reader` for a new stream. With no options it swaps the
+destination/source and preserves the configuration; any options passed reconfigure
+it for the new stream and persist until changed. Every option may be changed this
+way. Reconfiguration only happens on `Reset`, never mid-stream.
 
 `WithDecoderMaxSize(n)` caps the total number of decompressed bytes as a
 decompression-bomb guard. The default, 0, disables the limit.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Browse documentation: [![Go Reference](https://pkg.go.dev/badge/github.com/klaus
 * Simplified errors.
 * Dictionary code simplified.
 * All "unsafe" removed.
-* Allows using the zero value Reader/Writer (not proposed explicitly, but seems reasonable).
+* Allows using the zero value Encoder/Decoder/Reader/Writer (not proposed explicitly, but seems reasonable).
 
 ## Additions to proposal
 
@@ -53,8 +53,48 @@ Supporting `io.WriterTo` and `io.ReaderFrom` on `Writer` and `Reader`:
 
 Bytes interface:
 
-* Added `(*Writer).AppendCompress(dst, src []byte) []byte`
-* Added `(*Reader).AppendDecompress(dst, src []byte) ([]byte, error)`
+* Added `(*Encoder).AppendCompress(dst, src []byte) []byte`
+* Added `(*Decoder).AppendDecompress(dst, src []byte) ([]byte, error)`
+
+## Configuration split: Encoder / Decoder
+
+Configuration and the one-shot byte operations live on two config types, so a
+stream's settings can be prepared and reused independently of any single stream:
+
+```go
+type Encoder struct{ /* no exported fields */ }
+func NewEncoder() *Encoder
+func (*Encoder) SetLevel(int) error
+func (*Encoder) SetWindowSize(int) error
+func (*Encoder) SetLowMemory(bool)
+func (*Encoder) SetCRC(bool)
+func (*Encoder) AddDict(*Dict)
+func (*Encoder) SetRawDict([]byte)
+func (*Encoder) AppendCompress(dst, src []byte) []byte
+
+type Decoder struct{ /* no exported fields */ }
+func NewDecoder() *Decoder
+func (*Decoder) SetMaxSize(int64) error       // total decompressed-output cap; 0 = unlimited
+func (*Decoder) SetMaxWindowSize(int) error
+func (*Decoder) AddDict(*Dict)
+func (*Decoder) SetRawDict([]byte)
+func (*Decoder) AppendDecompress(dst, src []byte) ([]byte, error)
+```
+
+The streaming `Writer`/`Reader` are bound to a config object; a nil argument
+uses default configuration:
+
+```go
+func NewWriter(w io.Writer, e *Encoder) *Writer
+func NewReader(r io.Reader, d *Decoder) *Reader
+```
+
+One `Encoder`/`Decoder` may configure many `Writer`/`Reader` values. It must not
+be reconfigured while a bound `Writer`/`Reader` is mid-stream; reconfigure
+between streams (before the first write, or after `Close`, then `Reset`).
+
+`(*Decoder).SetMaxSize(n)` caps the total number of decompressed bytes as a
+decompression-bomb guard. The default, 0, disables the limit.
 
 # Pre-PR
 

--- a/_testref/ref_bench_test.go
+++ b/_testref/ref_bench_test.go
@@ -30,8 +30,10 @@ func BenchmarkAppendTo(b *testing.B) {
 	for _, level := range levels {
 		for name, data := range datasets {
 			b.Run(fmt.Sprintf("lite/level-%d/%s", level, name), func(b *testing.B) {
-				e := zstd.NewEncoder()
-				e.SetLevel(level)
+				e, err := zstd.NewEncoder(zstd.WithEncoderLevel(level))
+				if err != nil {
+					b.Fatal(err)
+				}
 				buf := make([]byte, 0, len(data))
 				b.SetBytes(int64(len(data)))
 				b.ResetTimer()
@@ -61,9 +63,10 @@ func BenchmarkStreamEncode(b *testing.B) {
 
 	for _, level := range levels {
 		b.Run(fmt.Sprintf("lite/level-%d/medium", level), func(b *testing.B) {
-			e := zstd.NewEncoder()
-			e.SetLevel(level)
-			w := zstd.NewWriter(nil, e)
+			w, err := zstd.NewWriter(nil, zstd.WithEncoderLevel(level))
+			if err != nil {
+				b.Fatal(err)
+			}
 			var buf bytes.Buffer
 			b.SetBytes(int64(len(medium)))
 			b.ResetTimer()
@@ -101,7 +104,10 @@ func BenchmarkAppendDecompress(b *testing.B) {
 			compressed := liteEncode(b, data, level)
 
 			b.Run(fmt.Sprintf("lite/level-%d/%s", level, name), func(b *testing.B) {
-				dec := zstd.NewDecoder()
+				dec, err := zstd.NewDecoder()
+				if err != nil {
+					b.Fatal(err)
+				}
 				buf := make([]byte, 0, len(data))
 				b.SetBytes(int64(len(data)))
 				b.ResetTimer()
@@ -137,7 +143,10 @@ func BenchmarkStreamDecode(b *testing.B) {
 			b.SetBytes(int64(len(medium)))
 			b.ResetTimer()
 			for range b.N {
-				r := zstd.NewReader(bytes.NewReader(compressed), nil)
+				r, err := zstd.NewReader(bytes.NewReader(compressed))
+				if err != nil {
+					b.Fatal(err)
+				}
 				io.ReadAll(r)
 				r.Close()
 			}

--- a/_testref/ref_bench_test.go
+++ b/_testref/ref_bench_test.go
@@ -30,13 +30,13 @@ func BenchmarkAppendTo(b *testing.B) {
 	for _, level := range levels {
 		for name, data := range datasets {
 			b.Run(fmt.Sprintf("lite/level-%d/%s", level, name), func(b *testing.B) {
-				w := zstd.NewWriter(nil)
-				w.SetLevel(level)
+				e := zstd.NewEncoder()
+				e.SetLevel(level)
 				buf := make([]byte, 0, len(data))
 				b.SetBytes(int64(len(data)))
 				b.ResetTimer()
 				for range b.N {
-					w.AppendCompress(buf[:0], data)
+					e.AppendCompress(buf[:0], data)
 				}
 			})
 			b.Run(fmt.Sprintf("ref/level-%d/%s", level, name), func(b *testing.B) {
@@ -61,8 +61,9 @@ func BenchmarkStreamEncode(b *testing.B) {
 
 	for _, level := range levels {
 		b.Run(fmt.Sprintf("lite/level-%d/medium", level), func(b *testing.B) {
-			w := zstd.NewWriter(nil)
-			w.SetLevel(level)
+			e := zstd.NewEncoder()
+			e.SetLevel(level)
+			w := zstd.NewWriter(nil, e)
 			var buf bytes.Buffer
 			b.SetBytes(int64(len(medium)))
 			b.ResetTimer()
@@ -100,13 +101,12 @@ func BenchmarkAppendDecompress(b *testing.B) {
 			compressed := liteEncode(b, data, level)
 
 			b.Run(fmt.Sprintf("lite/level-%d/%s", level, name), func(b *testing.B) {
-				r := zstd.NewReader(bytes.NewReader([]byte{0x28, 0xb5, 0x2f, 0xfd, 0x04, 0x00, 0x01, 0x00, 0x00}))
-				defer r.Close()
+				dec := zstd.NewDecoder()
 				buf := make([]byte, 0, len(data))
 				b.SetBytes(int64(len(data)))
 				b.ResetTimer()
 				for range b.N {
-					r.AppendDecompress(buf[:0], compressed)
+					dec.AppendDecompress(buf[:0], compressed)
 				}
 			})
 			b.Run(fmt.Sprintf("ref/level-%d/%s", level, name), func(b *testing.B) {
@@ -137,7 +137,7 @@ func BenchmarkStreamDecode(b *testing.B) {
 			b.SetBytes(int64(len(medium)))
 			b.ResetTimer()
 			for range b.N {
-				r := zstd.NewReader(bytes.NewReader(compressed))
+				r := zstd.NewReader(bytes.NewReader(compressed), nil)
 				io.ReadAll(r)
 				r.Close()
 			}

--- a/_testref/ref_decode_test.go
+++ b/_testref/ref_decode_test.go
@@ -232,7 +232,10 @@ func TestRefLiteDecodeReset(t *testing.T) {
 	c1 := refEncode(t, src1)
 	c2 := refEncode(t, src2)
 
-	r := zstd.NewReader(bytes.NewReader(c1), nil)
+	r, err := zstd.NewReader(bytes.NewReader(c1))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r.Close()
 	got1, err := readAll(r)
 	if err != nil {
@@ -258,11 +261,12 @@ func TestRefLiteDecodeMaxWindowSize(t *testing.T) {
 	compressed := refEncode(t, src, ref.WithWindowSize(8<<20))
 
 	// Try to decode with a small max window — should fail.
-	dec := zstd.NewDecoder()
-	dec.SetMaxWindowSize(1 << 10)
-	r := zstd.NewReader(bytes.NewReader(compressed), dec)
+	r, err := zstd.NewReader(bytes.NewReader(compressed), zstd.WithDecoderMaxWindow(1<<10))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r.Close()
-	_, err := readAll(r)
+	_, err = readAll(r)
 	if err == nil {
 		t.Error("expected error for small max window size, got nil")
 	}

--- a/_testref/ref_decode_test.go
+++ b/_testref/ref_decode_test.go
@@ -232,7 +232,7 @@ func TestRefLiteDecodeReset(t *testing.T) {
 	c1 := refEncode(t, src1)
 	c2 := refEncode(t, src2)
 
-	r := zstd.NewReader(bytes.NewReader(c1))
+	r := zstd.NewReader(bytes.NewReader(c1), nil)
 	defer r.Close()
 	got1, err := readAll(r)
 	if err != nil {
@@ -258,9 +258,10 @@ func TestRefLiteDecodeMaxWindowSize(t *testing.T) {
 	compressed := refEncode(t, src, ref.WithWindowSize(8<<20))
 
 	// Try to decode with a small max window — should fail.
-	r := zstd.NewReader(bytes.NewReader(compressed))
+	dec := zstd.NewDecoder()
+	dec.SetMaxWindowSize(1 << 10)
+	r := zstd.NewReader(bytes.NewReader(compressed), dec)
 	defer r.Close()
-	r.SetMaxWindowSize(1 << 10)
 	_, err := readAll(r)
 	if err == nil {
 		t.Error("expected error for small max window size, got nil")

--- a/_testref/ref_dict_test.go
+++ b/_testref/ref_dict_test.go
@@ -55,13 +55,14 @@ func TestRefDictMarshalRoundTrip(t *testing.T) {
 
 	// Encode with original, decode with unmarshalled.
 	src := testData(4096)
-	w := zstd.NewWriter(nil)
-	w.AddDict(liteDict)
-	compressed := w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	e.AddDict(liteDict)
+	compressed := e.AppendCompress(nil, src)
 
-	r := zstd.NewReader(bytes.NewReader(compressed))
+	dec := zstd.NewDecoder()
+	dec.AddDict(&d2)
+	r := zstd.NewReader(bytes.NewReader(compressed), dec)
 	defer r.Close()
-	r.AddDict(&d2)
 	got, err := readAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -76,10 +77,10 @@ func TestRefDictParsedLiteEncodeParentDecode(t *testing.T) {
 	src := testData(8192)
 
 	for _, level := range []int{1, 3, 5, 8} {
-		w := zstd.NewWriter(nil)
-		w.SetLevel(level)
-		w.AddDict(liteDict)
-		compressed := w.AppendCompress(nil, src)
+		e := zstd.NewEncoder()
+		e.SetLevel(level)
+		e.AddDict(liteDict)
+		compressed := e.AppendCompress(nil, src)
 
 		got := refDecode(t, compressed, ref.WithDecoderDicts(raw))
 		if !bytes.Equal(src, got) {
@@ -95,8 +96,9 @@ func TestRefDictParsedParentEncodeLiteDecode(t *testing.T) {
 	for _, rl := range []ref.EncoderLevel{ref.SpeedFastest, ref.SpeedDefault, ref.SpeedBetterCompression, ref.SpeedBestCompression} {
 		compressed := refEncode(t, src, ref.WithEncoderLevel(rl), ref.WithEncoderDict(raw))
 
-		r := zstd.NewReader(bytes.NewReader(compressed))
-		r.AddDict(liteDict)
+		dec := zstd.NewDecoder()
+		dec.AddDict(liteDict)
+		r := zstd.NewReader(bytes.NewReader(compressed), dec)
 		got, err := readAll(r)
 		r.Close()
 		if err != nil {
@@ -113,10 +115,10 @@ func TestRefDictRawLiteEncodeParentDecode(t *testing.T) {
 	src := testData(8192)
 
 	for _, level := range []int{1, 3, 5, 8, 9} {
-		w := zstd.NewWriter(nil)
-		w.SetLevel(level)
-		w.SetRawDict(rawDict)
-		compressed := w.AppendCompress(nil, src)
+		e := zstd.NewEncoder()
+		e.SetLevel(level)
+		e.SetRawDict(rawDict)
+		compressed := e.AppendCompress(nil, src)
 
 		got := refDecode(t, compressed, ref.WithDecoderDictRaw(0, rawDict))
 		if !bytes.Equal(src, got) {
@@ -132,8 +134,9 @@ func TestRefDictRawParentEncodeLiteDecode(t *testing.T) {
 	for _, rl := range []ref.EncoderLevel{ref.SpeedFastest, ref.SpeedDefault, ref.SpeedBetterCompression, ref.SpeedBestCompression} {
 		compressed := refEncode(t, src, ref.WithEncoderLevel(rl), ref.WithEncoderDictRaw(0, rawDict))
 
-		r := zstd.NewReader(bytes.NewReader(compressed))
-		r.SetRawDict(rawDict)
+		dec := zstd.NewDecoder()
+		dec.SetRawDict(rawDict)
+		r := zstd.NewReader(bytes.NewReader(compressed), dec)
 		got, err := readAll(r)
 		r.Close()
 		if err != nil {
@@ -150,9 +153,9 @@ func TestRefDictParsedAppendToBothDirs(t *testing.T) {
 	src := testData(4096)
 
 	// lite → parent
-	w := zstd.NewWriter(nil)
-	w.AddDict(liteDict)
-	compressed := w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	e.AddDict(liteDict)
+	compressed := e.AppendCompress(nil, src)
 	got := refDecode(t, compressed, ref.WithDecoderDicts(raw))
 	if !bytes.Equal(src, got) {
 		t.Error("parsed AppendTo lite→parent mismatch")
@@ -160,9 +163,10 @@ func TestRefDictParsedAppendToBothDirs(t *testing.T) {
 
 	// parent → lite
 	compressed = refEncode(t, src, ref.WithEncoderDict(raw))
-	r := zstd.NewReader(bytes.NewReader(compressed))
+	dec := zstd.NewDecoder()
+	dec.AddDict(liteDict)
+	r := zstd.NewReader(bytes.NewReader(compressed), dec)
 	defer r.Close()
-	r.AddDict(liteDict)
 	got, err := readAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -177,9 +181,9 @@ func TestRefDictRawAppendToBothDirs(t *testing.T) {
 	src := testData(4096)
 
 	// lite → parent
-	w := zstd.NewWriter(nil)
-	w.SetRawDict(rawDict)
-	compressed := w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	e.SetRawDict(rawDict)
+	compressed := e.AppendCompress(nil, src)
 	got := refDecode(t, compressed, ref.WithDecoderDictRaw(0, rawDict))
 	if !bytes.Equal(src, got) {
 		t.Error("raw AppendTo lite→parent mismatch")
@@ -187,9 +191,10 @@ func TestRefDictRawAppendToBothDirs(t *testing.T) {
 
 	// parent → lite
 	compressed = refEncode(t, src, ref.WithEncoderDictRaw(0, rawDict))
-	r := zstd.NewReader(bytes.NewReader(compressed))
+	dec := zstd.NewDecoder()
+	dec.SetRawDict(rawDict)
+	r := zstd.NewReader(bytes.NewReader(compressed), dec)
 	defer r.Close()
-	r.SetRawDict(rawDict)
 	got, err := readAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -205,8 +210,9 @@ func TestRefDictStreamBothDirs(t *testing.T) {
 
 	// lite stream → parent decode
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
-	w.AddDict(liteDict)
+	e := zstd.NewEncoder()
+	e.AddDict(liteDict)
+	w := zstd.NewWriter(&buf, e)
 	w.Write(src)
 	w.Close()
 	got := refDecode(t, buf.Bytes(), ref.WithDecoderDicts(raw))
@@ -216,9 +222,10 @@ func TestRefDictStreamBothDirs(t *testing.T) {
 
 	// parent stream → lite decode
 	compressed := refStreamEncode(t, src, ref.WithEncoderDict(raw))
-	r := zstd.NewReader(bytes.NewReader(compressed))
+	dec := zstd.NewDecoder()
+	dec.AddDict(liteDict)
+	r := zstd.NewReader(bytes.NewReader(compressed), dec)
 	defer r.Close()
-	r.AddDict(liteDict)
 	got, err := readAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -232,14 +239,14 @@ func TestRefDictClearAndReuse(t *testing.T) {
 	_, liteDict := loadDicts(t)
 	src := testData(4096)
 
-	w := zstd.NewWriter(nil)
-	w.AddDict(liteDict)
+	e := zstd.NewEncoder()
+	e.AddDict(liteDict)
 	// Encode with dict.
-	_ = w.AppendCompress(nil, src)
+	_ = e.AppendCompress(nil, src)
 
 	// Clear dict.
-	w.AddDict(nil)
-	compressed := w.AppendCompress(nil, src)
+	e.AddDict(nil)
+	compressed := e.AppendCompress(nil, src)
 
 	// Should decode without dict.
 	got := refDecode(t, compressed)

--- a/_testref/ref_dict_test.go
+++ b/_testref/ref_dict_test.go
@@ -55,13 +55,16 @@ func TestRefDictMarshalRoundTrip(t *testing.T) {
 
 	// Encode with original, decode with unmarshalled.
 	src := testData(4096)
-	e := zstd.NewEncoder()
-	e.AddDict(liteDict)
+	e, err := zstd.NewEncoder(zstd.WithEncoderDict(liteDict))
+	if err != nil {
+		t.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, src)
 
-	dec := zstd.NewDecoder()
-	dec.AddDict(&d2)
-	r := zstd.NewReader(bytes.NewReader(compressed), dec)
+	r, err := zstd.NewReader(bytes.NewReader(compressed), zstd.WithDecoderDict(&d2))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r.Close()
 	got, err := readAll(r)
 	if err != nil {
@@ -77,9 +80,10 @@ func TestRefDictParsedLiteEncodeParentDecode(t *testing.T) {
 	src := testData(8192)
 
 	for _, level := range []int{1, 3, 5, 8} {
-		e := zstd.NewEncoder()
-		e.SetLevel(level)
-		e.AddDict(liteDict)
+		e, err := zstd.NewEncoder(zstd.WithEncoderLevel(level), zstd.WithEncoderDict(liteDict))
+		if err != nil {
+			t.Fatal(err)
+		}
 		compressed := e.AppendCompress(nil, src)
 
 		got := refDecode(t, compressed, ref.WithDecoderDicts(raw))
@@ -96,9 +100,10 @@ func TestRefDictParsedParentEncodeLiteDecode(t *testing.T) {
 	for _, rl := range []ref.EncoderLevel{ref.SpeedFastest, ref.SpeedDefault, ref.SpeedBetterCompression, ref.SpeedBestCompression} {
 		compressed := refEncode(t, src, ref.WithEncoderLevel(rl), ref.WithEncoderDict(raw))
 
-		dec := zstd.NewDecoder()
-		dec.AddDict(liteDict)
-		r := zstd.NewReader(bytes.NewReader(compressed), dec)
+		r, err := zstd.NewReader(bytes.NewReader(compressed), zstd.WithDecoderDict(liteDict))
+		if err != nil {
+			t.Fatal(err)
+		}
 		got, err := readAll(r)
 		r.Close()
 		if err != nil {
@@ -115,9 +120,10 @@ func TestRefDictRawLiteEncodeParentDecode(t *testing.T) {
 	src := testData(8192)
 
 	for _, level := range []int{1, 3, 5, 8, 9} {
-		e := zstd.NewEncoder()
-		e.SetLevel(level)
-		e.SetRawDict(rawDict)
+		e, err := zstd.NewEncoder(zstd.WithEncoderLevel(level), zstd.WithEncoderRawDict(rawDict))
+		if err != nil {
+			t.Fatal(err)
+		}
 		compressed := e.AppendCompress(nil, src)
 
 		got := refDecode(t, compressed, ref.WithDecoderDictRaw(0, rawDict))
@@ -134,9 +140,10 @@ func TestRefDictRawParentEncodeLiteDecode(t *testing.T) {
 	for _, rl := range []ref.EncoderLevel{ref.SpeedFastest, ref.SpeedDefault, ref.SpeedBetterCompression, ref.SpeedBestCompression} {
 		compressed := refEncode(t, src, ref.WithEncoderLevel(rl), ref.WithEncoderDictRaw(0, rawDict))
 
-		dec := zstd.NewDecoder()
-		dec.SetRawDict(rawDict)
-		r := zstd.NewReader(bytes.NewReader(compressed), dec)
+		r, err := zstd.NewReader(bytes.NewReader(compressed), zstd.WithDecoderRawDict(rawDict))
+		if err != nil {
+			t.Fatal(err)
+		}
 		got, err := readAll(r)
 		r.Close()
 		if err != nil {
@@ -153,8 +160,10 @@ func TestRefDictParsedAppendToBothDirs(t *testing.T) {
 	src := testData(4096)
 
 	// lite → parent
-	e := zstd.NewEncoder()
-	e.AddDict(liteDict)
+	e, err := zstd.NewEncoder(zstd.WithEncoderDict(liteDict))
+	if err != nil {
+		t.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, src)
 	got := refDecode(t, compressed, ref.WithDecoderDicts(raw))
 	if !bytes.Equal(src, got) {
@@ -163,11 +172,12 @@ func TestRefDictParsedAppendToBothDirs(t *testing.T) {
 
 	// parent → lite
 	compressed = refEncode(t, src, ref.WithEncoderDict(raw))
-	dec := zstd.NewDecoder()
-	dec.AddDict(liteDict)
-	r := zstd.NewReader(bytes.NewReader(compressed), dec)
+	r, err := zstd.NewReader(bytes.NewReader(compressed), zstd.WithDecoderDict(liteDict))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r.Close()
-	got, err := readAll(r)
+	got, err = readAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,8 +191,10 @@ func TestRefDictRawAppendToBothDirs(t *testing.T) {
 	src := testData(4096)
 
 	// lite → parent
-	e := zstd.NewEncoder()
-	e.SetRawDict(rawDict)
+	e, err := zstd.NewEncoder(zstd.WithEncoderRawDict(rawDict))
+	if err != nil {
+		t.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, src)
 	got := refDecode(t, compressed, ref.WithDecoderDictRaw(0, rawDict))
 	if !bytes.Equal(src, got) {
@@ -191,11 +203,12 @@ func TestRefDictRawAppendToBothDirs(t *testing.T) {
 
 	// parent → lite
 	compressed = refEncode(t, src, ref.WithEncoderDictRaw(0, rawDict))
-	dec := zstd.NewDecoder()
-	dec.SetRawDict(rawDict)
-	r := zstd.NewReader(bytes.NewReader(compressed), dec)
+	r, err := zstd.NewReader(bytes.NewReader(compressed), zstd.WithDecoderRawDict(rawDict))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r.Close()
-	got, err := readAll(r)
+	got, err = readAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,9 +223,10 @@ func TestRefDictStreamBothDirs(t *testing.T) {
 
 	// lite stream → parent decode
 	var buf bytes.Buffer
-	e := zstd.NewEncoder()
-	e.AddDict(liteDict)
-	w := zstd.NewWriter(&buf, e)
+	w, err := zstd.NewWriter(&buf, zstd.WithEncoderDict(liteDict))
+	if err != nil {
+		t.Fatal(err)
+	}
 	w.Write(src)
 	w.Close()
 	got := refDecode(t, buf.Bytes(), ref.WithDecoderDicts(raw))
@@ -222,11 +236,12 @@ func TestRefDictStreamBothDirs(t *testing.T) {
 
 	// parent stream → lite decode
 	compressed := refStreamEncode(t, src, ref.WithEncoderDict(raw))
-	dec := zstd.NewDecoder()
-	dec.AddDict(liteDict)
-	r := zstd.NewReader(bytes.NewReader(compressed), dec)
+	r, err := zstd.NewReader(bytes.NewReader(compressed), zstd.WithDecoderDict(liteDict))
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r.Close()
-	got, err := readAll(r)
+	got, err = readAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,14 +254,19 @@ func TestRefDictClearAndReuse(t *testing.T) {
 	_, liteDict := loadDicts(t)
 	src := testData(4096)
 
-	e := zstd.NewEncoder()
-	e.AddDict(liteDict)
+	e, err := zstd.NewEncoder(zstd.WithEncoderDict(liteDict))
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Encode with dict.
 	_ = e.AppendCompress(nil, src)
 
-	// Clear dict.
-	e.AddDict(nil)
-	compressed := e.AppendCompress(nil, src)
+	// Clear dict: use a fresh encoder without a dict.
+	e2, err := zstd.NewEncoder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	compressed := e2.AppendCompress(nil, src)
 
 	// Should decode without dict.
 	got := refDecode(t, compressed)

--- a/_testref/ref_encode_test.go
+++ b/_testref/ref_encode_test.go
@@ -260,7 +260,9 @@ func TestRefLiteEncodeContentSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w.ResetContentSize(&buf, int64(len(src)))
+	if err := w.Reset(&buf, zstd.WithContentSize(int64(len(src)))); err != nil {
+		t.Fatal(err)
+	}
 	w.Write(src)
 	w.Close()
 	got := refDecode(t, buf.Bytes())

--- a/_testref/ref_encode_test.go
+++ b/_testref/ref_encode_test.go
@@ -26,8 +26,8 @@ func TestRefLiteAppendToLevels(t *testing.T) {
 }
 
 func TestRefLiteEncodeEmpty(t *testing.T) {
-	w := zstd.NewWriter(nil)
-	compressed := w.AppendCompress(nil, nil)
+	e := zstd.NewEncoder()
+	compressed := e.AppendCompress(nil, nil)
 	if len(compressed) == 0 {
 		t.Fatal("expected non-empty frame for nil input")
 	}
@@ -38,7 +38,7 @@ func TestRefLiteEncodeEmpty(t *testing.T) {
 
 	// Streaming: Write nothing, Close.
 	var buf bytes.Buffer
-	w.Reset(&buf)
+	w := zstd.NewWriter(&buf, e)
 	w.Close()
 	if buf.Len() == 0 {
 		t.Fatal("expected non-empty frame from streaming empty close")
@@ -118,8 +118,9 @@ func TestRefLiteEncodeStream(t *testing.T) {
 	src := testData(32768)
 	for _, level := range []int{1, 3, 5, 8} {
 		var buf bytes.Buffer
-		w := zstd.NewWriter(&buf)
-		w.SetLevel(level)
+		e := zstd.NewEncoder()
+		e.SetLevel(level)
+		w := zstd.NewWriter(&buf, e)
 		w.Write(src)
 		w.Close()
 		got := refDecode(t, buf.Bytes())
@@ -132,7 +133,7 @@ func TestRefLiteEncodeStream(t *testing.T) {
 func TestRefLiteEncodeStreamMultiWrite(t *testing.T) {
 	src := testData(4096)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
+	w := zstd.NewWriter(&buf, nil)
 	for i := 0; i < len(src); i += 7 {
 		end := min(i+7, len(src))
 		w.Write(src[i:end])
@@ -147,7 +148,7 @@ func TestRefLiteEncodeStreamMultiWrite(t *testing.T) {
 func TestRefLiteEncodeStreamByteByByte(t *testing.T) {
 	src := testData(512)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
+	w := zstd.NewWriter(&buf, nil)
 	for _, b := range src {
 		w.Write([]byte{b})
 	}
@@ -162,7 +163,7 @@ func TestRefLiteEncodeFlush(t *testing.T) {
 	src1 := testData(2048)
 	src2 := testData(1024)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
+	w := zstd.NewWriter(&buf, nil)
 	w.Write(src1)
 	if err := w.Flush(); err != nil {
 		t.Fatal(err)
@@ -182,7 +183,7 @@ func TestRefLiteEncodeFlush(t *testing.T) {
 func TestRefLiteEncodeReadFrom(t *testing.T) {
 	src := testData(32768)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
+	w := zstd.NewWriter(&buf, nil)
 	w.ReadFrom(bytes.NewReader(src))
 	w.Close()
 	got := refDecode(t, buf.Bytes())
@@ -193,9 +194,9 @@ func TestRefLiteEncodeReadFrom(t *testing.T) {
 
 func TestRefLiteEncodeCRCOn(t *testing.T) {
 	src := testData(4096)
-	w := zstd.NewWriter(nil)
-	w.SetCRC(true)
-	compressed := w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	e.SetCRC(true)
+	compressed := e.AppendCompress(nil, src)
 	got := refDecode(t, compressed)
 	if !bytes.Equal(src, got) {
 		t.Error("CRC on roundtrip mismatch")
@@ -204,9 +205,9 @@ func TestRefLiteEncodeCRCOn(t *testing.T) {
 
 func TestRefLiteEncodeCRCOff(t *testing.T) {
 	src := testData(4096)
-	w := zstd.NewWriter(nil)
-	w.SetCRC(false)
-	compressed := w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	e.SetCRC(false)
+	compressed := e.AppendCompress(nil, src)
 	got := refDecode(t, compressed, ref.IgnoreChecksum(true))
 	if !bytes.Equal(src, got) {
 		t.Error("CRC off roundtrip mismatch")
@@ -221,9 +222,9 @@ func TestRefLiteEncodeWindowSizes(t *testing.T) {
 			dataSize = 64
 		}
 		src := testData(dataSize)
-		compressed := liteEncodeOpts(t, src, func(w *zstd.Writer) {
-			w.SetLevel(3)
-			w.SetWindowSize(ws)
+		compressed := liteEncodeOpts(t, src, func(e *zstd.Encoder) {
+			e.SetLevel(3)
+			e.SetWindowSize(ws)
 		})
 		got := refDecode(t, compressed)
 		if !bytes.Equal(src, got) {
@@ -235,7 +236,7 @@ func TestRefLiteEncodeWindowSizes(t *testing.T) {
 func TestRefLiteEncodeContentSize(t *testing.T) {
 	src := testData(8192)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(nil)
+	w := zstd.NewWriter(nil, nil)
 	w.ResetContentSize(&buf, int64(len(src)))
 	w.Write(src)
 	w.Close()
@@ -247,9 +248,9 @@ func TestRefLiteEncodeContentSize(t *testing.T) {
 
 func TestRefLiteEncodeLowMem(t *testing.T) {
 	src := testData(32768)
-	compressed := liteEncodeOpts(t, src, func(w *zstd.Writer) {
-		w.SetLevel(3)
-		w.SetLowMemory(true)
+	compressed := liteEncodeOpts(t, src, func(e *zstd.Encoder) {
+		e.SetLevel(3)
+		e.SetLowMemory(true)
 	})
 	got := refDecode(t, compressed)
 	if !bytes.Equal(src, got) {
@@ -258,7 +259,7 @@ func TestRefLiteEncodeLowMem(t *testing.T) {
 }
 
 func TestRefLiteEncodeResetCycles(t *testing.T) {
-	w := zstd.NewWriter(nil)
+	w := zstd.NewWriter(nil, nil)
 	for i := range 10 {
 		src := testData(4096 + i*1024)
 		var buf bytes.Buffer
@@ -278,10 +279,10 @@ func TestRefLiteEncodeConcatenated(t *testing.T) {
 		testData(4096),
 		testData(1024),
 	}
-	w := zstd.NewWriter(nil)
+	e := zstd.NewEncoder()
 	var concat []byte
 	for _, p := range parts {
-		concat = w.AppendCompress(concat, p)
+		concat = e.AppendCompress(concat, p)
 	}
 	want := make([]byte, 0, 2048+4096+1024)
 	for _, p := range parts {
@@ -323,8 +324,9 @@ func TestRefLiteEncodeRandom(t *testing.T) {
 func liteStreamEncode(t testing.TB, src []byte, level int) []byte {
 	t.Helper()
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
-	w.SetLevel(level)
+	e := zstd.NewEncoder()
+	e.SetLevel(level)
+	w := zstd.NewWriter(&buf, e)
 	w.Write(src)
 	if err := w.Close(); err != nil {
 		t.Fatal(err)

--- a/_testref/ref_encode_test.go
+++ b/_testref/ref_encode_test.go
@@ -26,7 +26,10 @@ func TestRefLiteAppendToLevels(t *testing.T) {
 }
 
 func TestRefLiteEncodeEmpty(t *testing.T) {
-	e := zstd.NewEncoder()
+	e, err := zstd.NewEncoder()
+	if err != nil {
+		t.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, nil)
 	if len(compressed) == 0 {
 		t.Fatal("expected non-empty frame for nil input")
@@ -38,7 +41,10 @@ func TestRefLiteEncodeEmpty(t *testing.T) {
 
 	// Streaming: Write nothing, Close.
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, e)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	w.Close()
 	if buf.Len() == 0 {
 		t.Fatal("expected non-empty frame from streaming empty close")
@@ -118,9 +124,10 @@ func TestRefLiteEncodeStream(t *testing.T) {
 	src := testData(32768)
 	for _, level := range []int{1, 3, 5, 8} {
 		var buf bytes.Buffer
-		e := zstd.NewEncoder()
-		e.SetLevel(level)
-		w := zstd.NewWriter(&buf, e)
+		w, err := zstd.NewWriter(&buf, zstd.WithEncoderLevel(level))
+		if err != nil {
+			t.Fatal(err)
+		}
 		w.Write(src)
 		w.Close()
 		got := refDecode(t, buf.Bytes())
@@ -133,7 +140,10 @@ func TestRefLiteEncodeStream(t *testing.T) {
 func TestRefLiteEncodeStreamMultiWrite(t *testing.T) {
 	src := testData(4096)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < len(src); i += 7 {
 		end := min(i+7, len(src))
 		w.Write(src[i:end])
@@ -148,7 +158,10 @@ func TestRefLiteEncodeStreamMultiWrite(t *testing.T) {
 func TestRefLiteEncodeStreamByteByByte(t *testing.T) {
 	src := testData(512)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, b := range src {
 		w.Write([]byte{b})
 	}
@@ -163,7 +176,10 @@ func TestRefLiteEncodeFlush(t *testing.T) {
 	src1 := testData(2048)
 	src2 := testData(1024)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	w.Write(src1)
 	if err := w.Flush(); err != nil {
 		t.Fatal(err)
@@ -183,7 +199,10 @@ func TestRefLiteEncodeFlush(t *testing.T) {
 func TestRefLiteEncodeReadFrom(t *testing.T) {
 	src := testData(32768)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	w.ReadFrom(bytes.NewReader(src))
 	w.Close()
 	got := refDecode(t, buf.Bytes())
@@ -194,8 +213,10 @@ func TestRefLiteEncodeReadFrom(t *testing.T) {
 
 func TestRefLiteEncodeCRCOn(t *testing.T) {
 	src := testData(4096)
-	e := zstd.NewEncoder()
-	e.SetCRC(true)
+	e, err := zstd.NewEncoder(zstd.WithEncoderCRC(true))
+	if err != nil {
+		t.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, src)
 	got := refDecode(t, compressed)
 	if !bytes.Equal(src, got) {
@@ -205,8 +226,10 @@ func TestRefLiteEncodeCRCOn(t *testing.T) {
 
 func TestRefLiteEncodeCRCOff(t *testing.T) {
 	src := testData(4096)
-	e := zstd.NewEncoder()
-	e.SetCRC(false)
+	e, err := zstd.NewEncoder(zstd.WithEncoderCRC(false))
+	if err != nil {
+		t.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, src)
 	got := refDecode(t, compressed, ref.IgnoreChecksum(true))
 	if !bytes.Equal(src, got) {
@@ -222,10 +245,7 @@ func TestRefLiteEncodeWindowSizes(t *testing.T) {
 			dataSize = 64
 		}
 		src := testData(dataSize)
-		compressed := liteEncodeOpts(t, src, func(e *zstd.Encoder) {
-			e.SetLevel(3)
-			e.SetWindowSize(ws)
-		})
+		compressed := liteEncodeOpts(t, src, zstd.WithEncoderLevel(3), zstd.WithWindowSize(ws))
 		got := refDecode(t, compressed)
 		if !bytes.Equal(src, got) {
 			t.Errorf("window %d: roundtrip mismatch", ws)
@@ -236,7 +256,10 @@ func TestRefLiteEncodeWindowSizes(t *testing.T) {
 func TestRefLiteEncodeContentSize(t *testing.T) {
 	src := testData(8192)
 	var buf bytes.Buffer
-	w := zstd.NewWriter(nil, nil)
+	w, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	w.ResetContentSize(&buf, int64(len(src)))
 	w.Write(src)
 	w.Close()
@@ -248,10 +271,7 @@ func TestRefLiteEncodeContentSize(t *testing.T) {
 
 func TestRefLiteEncodeLowMem(t *testing.T) {
 	src := testData(32768)
-	compressed := liteEncodeOpts(t, src, func(e *zstd.Encoder) {
-		e.SetLevel(3)
-		e.SetLowMemory(true)
-	})
+	compressed := liteEncodeOpts(t, src, zstd.WithEncoderLevel(3), zstd.WithLowMemory(true))
 	got := refDecode(t, compressed)
 	if !bytes.Equal(src, got) {
 		t.Error("lowmem roundtrip mismatch")
@@ -259,7 +279,10 @@ func TestRefLiteEncodeLowMem(t *testing.T) {
 }
 
 func TestRefLiteEncodeResetCycles(t *testing.T) {
-	w := zstd.NewWriter(nil, nil)
+	w, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i := range 10 {
 		src := testData(4096 + i*1024)
 		var buf bytes.Buffer
@@ -279,7 +302,10 @@ func TestRefLiteEncodeConcatenated(t *testing.T) {
 		testData(4096),
 		testData(1024),
 	}
-	e := zstd.NewEncoder()
+	e, err := zstd.NewEncoder()
+	if err != nil {
+		t.Fatal(err)
+	}
 	var concat []byte
 	for _, p := range parts {
 		concat = e.AppendCompress(concat, p)
@@ -324,9 +350,10 @@ func TestRefLiteEncodeRandom(t *testing.T) {
 func liteStreamEncode(t testing.TB, src []byte, level int) []byte {
 	t.Helper()
 	var buf bytes.Buffer
-	e := zstd.NewEncoder()
-	e.SetLevel(level)
-	w := zstd.NewWriter(&buf, e)
+	w, err := zstd.NewWriter(&buf, zstd.WithEncoderLevel(level))
+	if err != nil {
+		t.Fatal(err)
+	}
 	w.Write(src)
 	if err := w.Close(); err != nil {
 		t.Fatal(err)

--- a/_testref/ref_errors_test.go
+++ b/_testref/ref_errors_test.go
@@ -32,7 +32,7 @@ func TestRefCorruptDataBothReject(t *testing.T) {
 	bad[len(bad)/2] ^= 0xff
 
 	// Lite should error.
-	r := zstd.NewReader(bytes.NewReader(bad))
+	r := zstd.NewReader(bytes.NewReader(bad), nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	liteErr := err != nil
@@ -57,7 +57,7 @@ func TestRefTruncatedStreamBothReject(t *testing.T) {
 	// Truncate to 75% of the compressed data.
 	trunc := compressed[:len(compressed)*3/4]
 
-	r := zstd.NewReader(bytes.NewReader(trunc))
+	r := zstd.NewReader(bytes.NewReader(trunc), nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	liteErr := err != nil
@@ -76,16 +76,16 @@ func TestRefTruncatedStreamBothReject(t *testing.T) {
 
 func TestRefBadChecksumBothReject(t *testing.T) {
 	src := testData(4096)
-	w := zstd.NewWriter(nil)
-	w.SetCRC(true)
-	compressed := w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	e.SetCRC(true)
+	compressed := e.AppendCompress(nil, src)
 
 	// Flip the last byte (CRC is at the end).
 	bad := make([]byte, len(compressed))
 	copy(bad, compressed)
 	bad[len(bad)-1] ^= 0xff
 
-	r := zstd.NewReader(bytes.NewReader(bad))
+	r := zstd.NewReader(bytes.NewReader(bad), nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	liteErr := err != nil
@@ -105,7 +105,7 @@ func TestRefBadChecksumBothReject(t *testing.T) {
 func TestRefWriteAfterClose(t *testing.T) {
 	// Lite encoder.
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
+	w := zstd.NewWriter(&buf, nil)
 	w.Write([]byte("hello"))
 	w.Close()
 	_, liteErr := w.Write([]byte("more"))

--- a/_testref/ref_errors_test.go
+++ b/_testref/ref_errors_test.go
@@ -32,8 +32,11 @@ func TestRefCorruptDataBothReject(t *testing.T) {
 	bad[len(bad)/2] ^= 0xff
 
 	// Lite should error.
-	r := zstd.NewReader(bytes.NewReader(bad), nil)
-	_, err := io.ReadAll(r)
+	r, err := zstd.NewReader(bytes.NewReader(bad))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(r)
 	r.Close()
 	liteErr := err != nil
 
@@ -57,8 +60,11 @@ func TestRefTruncatedStreamBothReject(t *testing.T) {
 	// Truncate to 75% of the compressed data.
 	trunc := compressed[:len(compressed)*3/4]
 
-	r := zstd.NewReader(bytes.NewReader(trunc), nil)
-	_, err := io.ReadAll(r)
+	r, err := zstd.NewReader(bytes.NewReader(trunc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(r)
 	r.Close()
 	liteErr := err != nil
 
@@ -76,8 +82,10 @@ func TestRefTruncatedStreamBothReject(t *testing.T) {
 
 func TestRefBadChecksumBothReject(t *testing.T) {
 	src := testData(4096)
-	e := zstd.NewEncoder()
-	e.SetCRC(true)
+	e, err := zstd.NewEncoder(zstd.WithEncoderCRC(true))
+	if err != nil {
+		t.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, src)
 
 	// Flip the last byte (CRC is at the end).
@@ -85,8 +93,11 @@ func TestRefBadChecksumBothReject(t *testing.T) {
 	copy(bad, compressed)
 	bad[len(bad)-1] ^= 0xff
 
-	r := zstd.NewReader(bytes.NewReader(bad), nil)
-	_, err := io.ReadAll(r)
+	r, err := zstd.NewReader(bytes.NewReader(bad))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(r)
 	r.Close()
 	liteErr := err != nil
 
@@ -105,7 +116,10 @@ func TestRefBadChecksumBothReject(t *testing.T) {
 func TestRefWriteAfterClose(t *testing.T) {
 	// Lite encoder.
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	w.Write([]byte("hello"))
 	w.Close()
 	_, liteErr := w.Write([]byte("more"))

--- a/_testref/ref_fuzz_test.go
+++ b/_testref/ref_fuzz_test.go
@@ -22,7 +22,7 @@ func FuzzRefEncoderCompat(f *testing.F) {
 	f.Add(testData(4096), 8)
 	f.Add(make([]byte, 100), 0)
 
-	w := zstd.NewWriter(nil)
+	enc := zstd.NewEncoder()
 	dec, err := ref.NewReader(nil)
 	if err != nil {
 		f.Fatal(err)
@@ -38,8 +38,8 @@ func FuzzRefEncoderCompat(f *testing.F) {
 		if len(data) > 1<<20 {
 			return
 		}
-		_ = w.SetLevel(level)
-		compressed = w.AppendCompress(compressed[:0], data)
+		_ = enc.SetLevel(level)
+		compressed = enc.AppendCompress(compressed[:0], data)
 		got, err = dec.DecodeAll(compressed, got[:0])
 		if err != nil {
 			t.Fatal(err)
@@ -65,7 +65,7 @@ func FuzzRefDecoderCompat(f *testing.F) {
 		}
 		encs[i] = enc
 	}
-	liteDec := zstd.NewReader(nil)
+	liteDec := zstd.NewDecoder()
 
 	var compressed, got []byte
 	f.Fuzz(func(t *testing.T, data []byte, levelHint int) {
@@ -103,8 +103,9 @@ func FuzzRefBothDecoders(f *testing.F) {
 	}
 	defer refDec.Close()
 
-	liteDec := zstd.NewReader(bytes.NewReader(nil))
-	liteDec.SetMaxWindowSize(maxWindow)
+	dec := zstd.NewDecoder()
+	dec.SetMaxWindowSize(maxWindow)
+	liteDec := zstd.NewReader(bytes.NewReader(nil), dec)
 	var refResult []byte
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Empty input: parent accepts (returns nil), lite rejects (ErrCorrupted).
@@ -131,7 +132,7 @@ func FuzzRefRawDictCompat(f *testing.F) {
 	f.Add(testData(256), testData(128))
 	f.Add(testData(1024), testData(512))
 
-	w := zstd.NewWriter(nil)
+	enc := zstd.NewEncoder()
 	var compressed, got []byte
 	refDec, err := ref.NewReader(nil)
 	if err != nil {
@@ -143,8 +144,7 @@ func FuzzRefRawDictCompat(f *testing.F) {
 		f.Fatal(err)
 	}
 	defer refEnc.Close()
-	dec := zstd.NewReader(nil)
-	defer dec.Close()
+	dec := zstd.NewDecoder()
 
 	f.Fuzz(func(t *testing.T, dictData, payload []byte) {
 		if len(dictData) == 0 || len(payload) == 0 {
@@ -158,11 +158,11 @@ func FuzzRefRawDictCompat(f *testing.F) {
 		}
 
 		// Encode with new std, decode with reference.
-		w.SetRawDict(dictData)
+		enc.SetRawDict(dictData)
 		if len(payload) > 0 {
-			w.SetLevel(int(payload[0] % 10))
+			enc.SetLevel(int(payload[0] % 10))
 		}
-		compressed = w.AppendCompress(compressed[:0], payload)
+		compressed = enc.AppendCompress(compressed[:0], payload)
 		err = refDec.ResetWithOptions(nil, ref.WithDecoderDictRaw(0, dictData))
 		if err != nil {
 			t.Fatal(err)
@@ -216,9 +216,8 @@ func FuzzRefDictCompat(f *testing.F) {
 	f.Add(dictFor(testData(128)), testData(128))
 	f.Add(dictFor(testData(1024)), testData(512))
 
-	w := zstd.NewWriter(nil)
-	dec := zstd.NewReader(nil)
-	defer dec.Close()
+	enc := zstd.NewEncoder()
+	dec := zstd.NewDecoder()
 	refDec, err := ref.NewReader(nil)
 	if err != nil {
 		f.Fatal(err)
@@ -249,11 +248,11 @@ func FuzzRefDictCompat(f *testing.F) {
 		}
 
 		// Encode with new std, decode with reference.
-		w.AddDict(gotDict)
+		enc.AddDict(gotDict)
 		if len(payload) > 0 {
-			w.SetLevel(int(payload[0] % 10))
+			enc.SetLevel(int(payload[0] % 10))
 		}
-		compressed = w.AppendCompress(compressed[:0], payload)
+		compressed = enc.AppendCompress(compressed[:0], payload)
 		err = refDec.ResetWithOptions(nil, ref.WithDecoderDicts(dictData))
 		if err != nil {
 			t.Fatal(err)

--- a/_testref/ref_fuzz_test.go
+++ b/_testref/ref_fuzz_test.go
@@ -22,7 +22,6 @@ func FuzzRefEncoderCompat(f *testing.F) {
 	f.Add(testData(4096), 8)
 	f.Add(make([]byte, 100), 0)
 
-	enc := zstd.NewEncoder()
 	dec, err := ref.NewReader(nil)
 	if err != nil {
 		f.Fatal(err)
@@ -38,7 +37,10 @@ func FuzzRefEncoderCompat(f *testing.F) {
 		if len(data) > 1<<20 {
 			return
 		}
-		_ = enc.SetLevel(level)
+		enc, err := zstd.NewEncoder(zstd.WithEncoderLevel(level))
+		if err != nil {
+			t.Fatal(err)
+		}
 		compressed = enc.AppendCompress(compressed[:0], data)
 		got, err = dec.DecodeAll(compressed, got[:0])
 		if err != nil {
@@ -65,7 +67,10 @@ func FuzzRefDecoderCompat(f *testing.F) {
 		}
 		encs[i] = enc
 	}
-	liteDec := zstd.NewDecoder()
+	liteDec, err := zstd.NewDecoder()
+	if err != nil {
+		f.Fatal(err)
+	}
 
 	var compressed, got []byte
 	f.Fuzz(func(t *testing.T, data []byte, levelHint int) {
@@ -103,9 +108,10 @@ func FuzzRefBothDecoders(f *testing.F) {
 	}
 	defer refDec.Close()
 
-	dec := zstd.NewDecoder()
-	dec.SetMaxWindowSize(maxWindow)
-	liteDec := zstd.NewReader(bytes.NewReader(nil), dec)
+	liteDec, err := zstd.NewReader(bytes.NewReader(nil), zstd.WithDecoderMaxWindow(maxWindow))
+	if err != nil {
+		f.Fatal(err)
+	}
 	var refResult []byte
 	f.Fuzz(func(t *testing.T, data []byte) {
 		// Empty input: parent accepts (returns nil), lite rejects (ErrCorrupted).
@@ -132,7 +138,6 @@ func FuzzRefRawDictCompat(f *testing.F) {
 	f.Add(testData(256), testData(128))
 	f.Add(testData(1024), testData(512))
 
-	enc := zstd.NewEncoder()
 	var compressed, got []byte
 	refDec, err := ref.NewReader(nil)
 	if err != nil {
@@ -144,7 +149,6 @@ func FuzzRefRawDictCompat(f *testing.F) {
 		f.Fatal(err)
 	}
 	defer refEnc.Close()
-	dec := zstd.NewDecoder()
 
 	f.Fuzz(func(t *testing.T, dictData, payload []byte) {
 		if len(dictData) == 0 || len(payload) == 0 {
@@ -158,9 +162,13 @@ func FuzzRefRawDictCompat(f *testing.F) {
 		}
 
 		// Encode with new std, decode with reference.
-		enc.SetRawDict(dictData)
+		encOpts := []zstd.EncoderOption{zstd.WithEncoderRawDict(dictData)}
 		if len(payload) > 0 {
-			enc.SetLevel(int(payload[0] % 10))
+			encOpts = append(encOpts, zstd.WithEncoderLevel(int(payload[0]%10)))
+		}
+		enc, err := zstd.NewEncoder(encOpts...)
+		if err != nil {
+			t.Fatal(err)
 		}
 		compressed = enc.AppendCompress(compressed[:0], payload)
 		err = refDec.ResetWithOptions(nil, ref.WithDecoderDictRaw(0, dictData))
@@ -178,7 +186,10 @@ func FuzzRefRawDictCompat(f *testing.F) {
 			t.Fatal(err)
 		}
 		compressed = refEnc.EncodeAll(payload, compressed[:0])
-		dec.SetRawDict(dictData)
+		dec, err := zstd.NewDecoder(zstd.WithDecoderRawDict(dictData))
+		if err != nil {
+			t.Fatal(err)
+		}
 		got, err = dec.AppendDecompress(got[:0], compressed)
 		if err != nil {
 			var refErr error
@@ -216,8 +227,6 @@ func FuzzRefDictCompat(f *testing.F) {
 	f.Add(dictFor(testData(128)), testData(128))
 	f.Add(dictFor(testData(1024)), testData(512))
 
-	enc := zstd.NewEncoder()
-	dec := zstd.NewDecoder()
 	refDec, err := ref.NewReader(nil)
 	if err != nil {
 		f.Fatal(err)
@@ -248,9 +257,13 @@ func FuzzRefDictCompat(f *testing.F) {
 		}
 
 		// Encode with new std, decode with reference.
-		enc.AddDict(gotDict)
+		encOpts := []zstd.EncoderOption{zstd.WithEncoderDict(gotDict)}
 		if len(payload) > 0 {
-			enc.SetLevel(int(payload[0] % 10))
+			encOpts = append(encOpts, zstd.WithEncoderLevel(int(payload[0]%10)))
+		}
+		enc, err := zstd.NewEncoder(encOpts...)
+		if err != nil {
+			t.Fatal(err)
 		}
 		compressed = enc.AppendCompress(compressed[:0], payload)
 		err = refDec.ResetWithOptions(nil, ref.WithDecoderDicts(dictData))
@@ -264,7 +277,10 @@ func FuzzRefDictCompat(f *testing.F) {
 
 		// Encode with reference, decode with new std.
 		compressed = refEnc.EncodeAll(payload, compressed[:0])
-		dec.AddDict(gotDict)
+		dec, err := zstd.NewDecoder(zstd.WithDecoderDict(gotDict))
+		if err != nil {
+			t.Fatal(err)
+		}
 		got, err = dec.AppendDecompress(got[:0], compressed)
 		if err != nil {
 			t.Fatal(err)

--- a/_testref/ref_test.go
+++ b/_testref/ref_test.go
@@ -58,35 +58,36 @@ func refDecode(t testing.TB, compressed []byte, opts ...ref.DOption) []byte {
 
 func liteEncode(t testing.TB, src []byte, level int) []byte {
 	t.Helper()
-	w := zstd.NewWriter(nil)
-	if err := w.SetLevel(level); err != nil {
+	e := zstd.NewEncoder()
+	if err := e.SetLevel(level); err != nil {
 		t.Fatal(err)
 	}
-	return w.AppendCompress(nil, src)
+	return e.AppendCompress(nil, src)
 }
 
-func liteEncodeOpts(t testing.TB, src []byte, setup func(*zstd.Writer)) []byte {
+func liteEncodeOpts(t testing.TB, src []byte, setup func(*zstd.Encoder)) []byte {
 	t.Helper()
-	w := zstd.NewWriter(nil)
-	setup(w)
-	return w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	setup(e)
+	return e.AppendCompress(nil, src)
 }
 
 func liteDecode(t testing.TB, compressed []byte) []byte {
 	t.Helper()
-	r := zstd.NewReader(nil)
-	got, err := r.AppendDecompress(nil, compressed)
+	d := zstd.NewDecoder()
+	got, err := d.AppendDecompress(nil, compressed)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return got
 }
 
-func liteDecodeOpts(t testing.TB, compressed []byte, setup func(*zstd.Reader)) []byte {
+func liteDecodeOpts(t testing.TB, compressed []byte, setup func(*zstd.Decoder)) []byte {
 	t.Helper()
-	r := zstd.NewReader(bytes.NewReader(compressed))
+	d := zstd.NewDecoder()
+	setup(d)
+	r := zstd.NewReader(bytes.NewReader(compressed), d)
 	defer r.Close()
-	setup(r)
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)

--- a/_testref/ref_test.go
+++ b/_testref/ref_test.go
@@ -58,23 +58,28 @@ func refDecode(t testing.TB, compressed []byte, opts ...ref.DOption) []byte {
 
 func liteEncode(t testing.TB, src []byte, level int) []byte {
 	t.Helper()
-	e := zstd.NewEncoder()
-	if err := e.SetLevel(level); err != nil {
+	e, err := zstd.NewEncoder(zstd.WithEncoderLevel(level))
+	if err != nil {
 		t.Fatal(err)
 	}
 	return e.AppendCompress(nil, src)
 }
 
-func liteEncodeOpts(t testing.TB, src []byte, setup func(*zstd.Encoder)) []byte {
+func liteEncodeOpts(t testing.TB, src []byte, opts ...zstd.EncoderOption) []byte {
 	t.Helper()
-	e := zstd.NewEncoder()
-	setup(e)
+	e, err := zstd.NewEncoder(opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	return e.AppendCompress(nil, src)
 }
 
 func liteDecode(t testing.TB, compressed []byte) []byte {
 	t.Helper()
-	d := zstd.NewDecoder()
+	d, err := zstd.NewDecoder()
+	if err != nil {
+		t.Fatal(err)
+	}
 	got, err := d.AppendDecompress(nil, compressed)
 	if err != nil {
 		t.Fatal(err)
@@ -82,11 +87,12 @@ func liteDecode(t testing.TB, compressed []byte) []byte {
 	return got
 }
 
-func liteDecodeOpts(t testing.TB, compressed []byte, setup func(*zstd.Decoder)) []byte {
+func liteDecodeOpts(t testing.TB, compressed []byte, opts ...zstd.DecoderOption) []byte {
 	t.Helper()
-	d := zstd.NewDecoder()
-	setup(d)
-	r := zstd.NewReader(bytes.NewReader(compressed), d)
+	r, err := zstd.NewReader(bytes.NewReader(compressed), opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {

--- a/bench_test.go
+++ b/bench_test.go
@@ -114,14 +114,14 @@ func BenchmarkAppendCompress(b *testing.B) {
 	for _, input := range benchInputs {
 		for _, lvl := range benchLevels {
 			b.Run(input.name+"/"+lvl.name, func(b *testing.B) {
-				w := NewWriter(nil)
-				_ = w.SetLevel(lvl.level)
+				e := NewEncoder()
+				_ = e.SetLevel(lvl.level)
 				var dst []byte
 				b.SetBytes(int64(len(input.data)))
 				b.ReportAllocs()
 				b.ResetTimer()
 				for range b.N {
-					dst = w.AppendCompress(dst[:0], input.data)
+					dst = e.AppendCompress(dst[:0], input.data)
 				}
 				b.StopTimer()
 				b.ReportMetric(100-100*float64(len(dst))/float64(len(input.data)), "reduction%")
@@ -142,8 +142,9 @@ func BenchmarkWrite(b *testing.B) {
 		for _, lvl := range benchLevels {
 			b.Run(input.name+"/"+lvl.name, func(b *testing.B) {
 				var cw countWriter
-				w := NewWriter(&cw)
-				_ = w.SetLevel(lvl.level)
+				e := NewEncoder()
+				_ = e.SetLevel(lvl.level)
+				w := NewWriter(&cw, e)
 				b.SetBytes(int64(len(input.data)))
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -165,8 +166,9 @@ func BenchmarkReadFrom(b *testing.B) {
 		for _, lvl := range benchLevels {
 			b.Run(input.name+"/"+lvl.name, func(b *testing.B) {
 				var cw countWriter
-				w := NewWriter(&cw)
-				_ = w.SetLevel(lvl.level)
+				e := NewEncoder()
+				_ = e.SetLevel(lvl.level)
+				w := NewWriter(&cw, e)
 				b.SetBytes(int64(len(input.data)))
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -190,14 +192,14 @@ type preCompressed struct {
 }
 
 func preCompress(inputs []benchInput, level int) []preCompressed {
-	w := NewWriter(nil)
-	_ = w.SetLevel(level)
+	e := NewEncoder()
+	_ = e.SetLevel(level)
 	out := make([]preCompressed, len(inputs))
 	for i, in := range inputs {
 		out[i] = preCompressed{
 			name:       in.name,
 			src:        in.data,
-			compressed: w.AppendCompress(nil, in.data),
+			compressed: e.AppendCompress(nil, in.data),
 		}
 	}
 	return out
@@ -208,13 +210,13 @@ func BenchmarkAppendDecompress(b *testing.B) {
 		pcs := preCompress(benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				r := NewReader(nil)
+				d := NewDecoder()
 				var dst []byte
 				b.SetBytes(int64(len(pc.src)))
 				b.ReportAllocs()
 				b.ResetTimer()
 				for range b.N {
-					dst, _ = r.AppendDecompress(dst[:0], pc.compressed)
+					dst, _ = d.AppendDecompress(dst[:0], pc.compressed)
 				}
 			})
 		}
@@ -226,7 +228,7 @@ func BenchmarkRead(b *testing.B) {
 		pcs := preCompress(benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				r := NewReader(bytes.NewReader(pc.compressed))
+				r := NewReader(bytes.NewReader(pc.compressed), nil)
 				b.SetBytes(int64(len(pc.src)))
 				b.ResetTimer()
 				for range b.N {
@@ -243,7 +245,7 @@ func BenchmarkWriteTo(b *testing.B) {
 		pcs := preCompress(benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				r := NewReader(bytes.NewReader(pc.compressed))
+				r := NewReader(bytes.NewReader(pc.compressed), nil)
 				b.SetBytes(int64(len(pc.src)))
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -262,26 +264,26 @@ func BenchmarkAppendCompress_Dict(b *testing.B) {
 
 	for _, lvl := range benchLevels {
 		b.Run("no-dict/"+lvl.name, func(b *testing.B) {
-			w := NewWriter(nil)
-			_ = w.SetLevel(lvl.level)
+			e := NewEncoder()
+			_ = e.SetLevel(lvl.level)
 			var dst []byte
 			b.SetBytes(int64(len(src)))
 			b.ResetTimer()
 			for range b.N {
-				dst = w.AppendCompress(dst[:0], src)
+				dst = e.AppendCompress(dst[:0], src)
 			}
 			b.StopTimer()
 			b.ReportMetric(100-100*float64(len(dst))/float64(len(src)), "reduction%")
 		})
 		b.Run("with-dict/"+lvl.name, func(b *testing.B) {
-			w := NewWriter(nil)
-			_ = w.SetLevel(lvl.level)
-			w.SetRawDict(dict)
+			e := NewEncoder()
+			_ = e.SetLevel(lvl.level)
+			e.SetRawDict(dict)
 			var dst []byte
 			b.SetBytes(int64(len(src)))
 			b.ResetTimer()
 			for range b.N {
-				dst = w.AppendCompress(dst[:0], src)
+				dst = e.AppendCompress(dst[:0], src)
 			}
 			b.StopTimer()
 			b.ReportMetric(100-100*float64(len(dst))/float64(len(src)), "reduction%")
@@ -294,19 +296,19 @@ func BenchmarkAppendDecompress_Dict(b *testing.B) {
 	src := genJSON(64*1024, 91)
 
 	for _, lvl := range benchLevels {
-		w := NewWriter(nil)
-		_ = w.SetLevel(lvl.level)
-		w.SetRawDict(dict)
-		compressed := w.AppendCompress(nil, src)
+		e := NewEncoder()
+		_ = e.SetLevel(lvl.level)
+		e.SetRawDict(dict)
+		compressed := e.AppendCompress(nil, src)
 
 		b.Run(lvl.name, func(b *testing.B) {
-			r := NewReader(nil)
-			r.SetRawDict(dict)
+			d := NewDecoder()
+			d.SetRawDict(dict)
 			var dst []byte
 			b.SetBytes(int64(len(src)))
 			b.ResetTimer()
 			for range b.N {
-				dst, _ = r.AppendDecompress(dst[:0], compressed)
+				dst, _ = d.AppendDecompress(dst[:0], compressed)
 			}
 			b.StopTimer()
 			b.ReportMetric(100-100*float64(len(compressed))/float64(len(src)), "reduction%")
@@ -316,19 +318,19 @@ func BenchmarkAppendDecompress_Dict(b *testing.B) {
 
 func BenchmarkNewWriter(b *testing.B) {
 	for range b.N {
-		_ = NewWriter(io.Discard)
+		_ = NewWriter(io.Discard, nil)
 	}
 }
 
 func BenchmarkNewReader(b *testing.B) {
 	for range b.N {
-		_ = NewReader(nil)
+		_ = NewReader(nil, nil)
 	}
 }
 
 func BenchmarkWriterReuse(b *testing.B) {
 	src := bytes.Repeat([]byte("reuse bench "), 500)
-	w := NewWriter(io.Discard)
+	w := NewWriter(io.Discard, nil)
 	b.SetBytes(int64(len(src)))
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -341,9 +343,9 @@ func BenchmarkWriterReuse(b *testing.B) {
 
 func BenchmarkReaderReuse(b *testing.B) {
 	src := bytes.Repeat([]byte("reuse bench "), 500)
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
-	r := NewReader(bytes.NewReader(compressed))
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
+	r := NewReader(bytes.NewReader(compressed), nil)
 	b.SetBytes(int64(len(src)))
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/bench_test.go
+++ b/bench_test.go
@@ -114,8 +114,7 @@ func BenchmarkAppendCompress(b *testing.B) {
 	for _, input := range benchInputs {
 		for _, lvl := range benchLevels {
 			b.Run(input.name+"/"+lvl.name, func(b *testing.B) {
-				e := NewEncoder()
-				_ = e.SetLevel(lvl.level)
+				e := mustEncoder(b, WithEncoderLevel(lvl.level))
 				var dst []byte
 				b.SetBytes(int64(len(input.data)))
 				b.ReportAllocs()
@@ -142,9 +141,7 @@ func BenchmarkWrite(b *testing.B) {
 		for _, lvl := range benchLevels {
 			b.Run(input.name+"/"+lvl.name, func(b *testing.B) {
 				var cw countWriter
-				e := NewEncoder()
-				_ = e.SetLevel(lvl.level)
-				w := NewWriter(&cw, e)
+				w := mustWriter(b, &cw, WithEncoderLevel(lvl.level))
 				b.SetBytes(int64(len(input.data)))
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -166,9 +163,7 @@ func BenchmarkReadFrom(b *testing.B) {
 		for _, lvl := range benchLevels {
 			b.Run(input.name+"/"+lvl.name, func(b *testing.B) {
 				var cw countWriter
-				e := NewEncoder()
-				_ = e.SetLevel(lvl.level)
-				w := NewWriter(&cw, e)
+				w := mustWriter(b, &cw, WithEncoderLevel(lvl.level))
 				b.SetBytes(int64(len(input.data)))
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -191,9 +186,8 @@ type preCompressed struct {
 	compressed []byte
 }
 
-func preCompress(inputs []benchInput, level int) []preCompressed {
-	e := NewEncoder()
-	_ = e.SetLevel(level)
+func preCompress(b *testing.B, inputs []benchInput, level int) []preCompressed {
+	e := mustEncoder(b, WithEncoderLevel(level))
 	out := make([]preCompressed, len(inputs))
 	for i, in := range inputs {
 		out[i] = preCompressed{
@@ -207,10 +201,10 @@ func preCompress(inputs []benchInput, level int) []preCompressed {
 
 func BenchmarkAppendDecompress(b *testing.B) {
 	for _, lvl := range benchLevels {
-		pcs := preCompress(benchInputs, lvl.level)
+		pcs := preCompress(b, benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				d := NewDecoder()
+				d := mustDecoder(b)
 				var dst []byte
 				b.SetBytes(int64(len(pc.src)))
 				b.ReportAllocs()
@@ -225,10 +219,10 @@ func BenchmarkAppendDecompress(b *testing.B) {
 
 func BenchmarkRead(b *testing.B) {
 	for _, lvl := range benchLevels {
-		pcs := preCompress(benchInputs, lvl.level)
+		pcs := preCompress(b, benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				r := NewReader(bytes.NewReader(pc.compressed), nil)
+				r := mustReader(b, bytes.NewReader(pc.compressed))
 				b.SetBytes(int64(len(pc.src)))
 				b.ResetTimer()
 				for range b.N {
@@ -242,10 +236,10 @@ func BenchmarkRead(b *testing.B) {
 
 func BenchmarkWriteTo(b *testing.B) {
 	for _, lvl := range benchLevels {
-		pcs := preCompress(benchInputs, lvl.level)
+		pcs := preCompress(b, benchInputs, lvl.level)
 		for _, pc := range pcs {
 			b.Run(pc.name+"/"+lvl.name, func(b *testing.B) {
-				r := NewReader(bytes.NewReader(pc.compressed), nil)
+				r := mustReader(b, bytes.NewReader(pc.compressed))
 				b.SetBytes(int64(len(pc.src)))
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -264,8 +258,7 @@ func BenchmarkAppendCompress_Dict(b *testing.B) {
 
 	for _, lvl := range benchLevels {
 		b.Run("no-dict/"+lvl.name, func(b *testing.B) {
-			e := NewEncoder()
-			_ = e.SetLevel(lvl.level)
+			e := mustEncoder(b, WithEncoderLevel(lvl.level))
 			var dst []byte
 			b.SetBytes(int64(len(src)))
 			b.ResetTimer()
@@ -276,9 +269,7 @@ func BenchmarkAppendCompress_Dict(b *testing.B) {
 			b.ReportMetric(100-100*float64(len(dst))/float64(len(src)), "reduction%")
 		})
 		b.Run("with-dict/"+lvl.name, func(b *testing.B) {
-			e := NewEncoder()
-			_ = e.SetLevel(lvl.level)
-			e.SetRawDict(dict)
+			e := mustEncoder(b, WithEncoderLevel(lvl.level), WithEncoderRawDict(dict))
 			var dst []byte
 			b.SetBytes(int64(len(src)))
 			b.ResetTimer()
@@ -296,14 +287,11 @@ func BenchmarkAppendDecompress_Dict(b *testing.B) {
 	src := genJSON(64*1024, 91)
 
 	for _, lvl := range benchLevels {
-		e := NewEncoder()
-		_ = e.SetLevel(lvl.level)
-		e.SetRawDict(dict)
+		e := mustEncoder(b, WithEncoderLevel(lvl.level), WithEncoderRawDict(dict))
 		compressed := e.AppendCompress(nil, src)
 
 		b.Run(lvl.name, func(b *testing.B) {
-			d := NewDecoder()
-			d.SetRawDict(dict)
+			d := mustDecoder(b, WithDecoderRawDict(dict))
 			var dst []byte
 			b.SetBytes(int64(len(src)))
 			b.ResetTimer()
@@ -318,19 +306,19 @@ func BenchmarkAppendDecompress_Dict(b *testing.B) {
 
 func BenchmarkNewWriter(b *testing.B) {
 	for range b.N {
-		_ = NewWriter(io.Discard, nil)
+		_, _ = NewWriter(io.Discard)
 	}
 }
 
 func BenchmarkNewReader(b *testing.B) {
 	for range b.N {
-		_ = NewReader(nil, nil)
+		_, _ = NewReader(nil)
 	}
 }
 
 func BenchmarkWriterReuse(b *testing.B) {
 	src := bytes.Repeat([]byte("reuse bench "), 500)
-	w := NewWriter(io.Discard, nil)
+	w := mustWriter(b, io.Discard)
 	b.SetBytes(int64(len(src)))
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -343,9 +331,9 @@ func BenchmarkWriterReuse(b *testing.B) {
 
 func BenchmarkReaderReuse(b *testing.B) {
 	src := bytes.Repeat([]byte("reuse bench "), 500)
-	e := NewEncoder()
+	e := mustEncoder(b)
 	compressed := e.AppendCompress(nil, src)
-	r := NewReader(bytes.NewReader(compressed), nil)
+	r := mustReader(b, bytes.NewReader(compressed))
 	b.SetBytes(int64(len(src)))
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/blockdec.go
+++ b/blockdec.go
@@ -44,6 +44,7 @@ const (
 
 // Decoder object pools for reuse across blocks.
 var (
+	blockDecPool    sync.Pool
 	huffDecoderPool = sync.Pool{New: func() any { return &huff0.Scratch{} }}
 	fseDecoderPool  = sync.Pool{New: func() any { return &fseDecoder{} }}
 )

--- a/decoder.go
+++ b/decoder.go
@@ -46,8 +46,9 @@ func NewDecoder(opts ...DecoderOption) (*Decoder, error) {
 	return d, nil
 }
 
-// DecoderOption configures a [Decoder]. Options are passed to [NewDecoder] and
-// [NewReader].
+// DecoderOption configures a [Decoder]. Options are passed to [NewDecoder],
+// [NewReader], and [Reader.Reset]. Every option may be changed via
+// [Reader.Reset]; the new configuration applies from the next frame.
 type DecoderOption func(*Decoder) error
 
 // WithDecoderMaxWindow sets the maximum allowed window size for decoding.

--- a/decoder.go
+++ b/decoder.go
@@ -16,9 +16,8 @@ var defaultDecoderOptions = decoderOptions{
 }
 
 // Decoder holds decompression configuration and provides one-shot decompression
-// via [Decoder.AppendDecompress]. A single Decoder may be passed to any number
-// of [NewReader] calls; it must not be reconfigured while a bound Reader is
-// mid-stream.
+// via [Decoder.AppendDecompress]. Configuration is fixed at construction via
+// [DecoderOption] values and is immutable afterwards.
 type Decoder struct {
 	o     decoderOptions
 	dicts map[uint32]*dict
@@ -33,27 +32,39 @@ func (d *Decoder) ensureInit() {
 	})
 }
 
-// NewDecoder returns a new Decoder configured with default limits.
-func NewDecoder() *Decoder {
+// NewDecoder returns a new Decoder configured by opts. Options are applied in
+// order; a later option overrides an earlier one. With no options the Decoder
+// uses default limits.
+func NewDecoder(opts ...DecoderOption) (*Decoder, error) {
 	d := &Decoder{}
 	d.ensureInit()
-	return d
+	for _, o := range opts {
+		if err := o(d); err != nil {
+			return nil, err
+		}
+	}
+	return d, nil
 }
 
-// SetMaxWindowSize sets the maximum allowed window size for decoding.
+// DecoderOption configures a [Decoder]. Options are passed to [NewDecoder] and
+// [NewReader].
+type DecoderOption func(*Decoder) error
+
+// WithDecoderMaxWindow sets the maximum allowed window size for decoding.
 // The default is 128 MiB.
 //
 // n must be in the range [MinWindowSize, MaxWindowSize].
-func (d *Decoder) SetMaxWindowSize(n int) error {
-	d.ensureInit()
-	if n < MinWindowSize || n > MaxWindowSize {
-		return fmt.Errorf("zstd: max window size %d out of range [%d, %d]", n, MinWindowSize, MaxWindowSize)
+func WithDecoderMaxWindow(n int) DecoderOption {
+	return func(d *Decoder) error {
+		if n < MinWindowSize || n > MaxWindowSize {
+			return fmt.Errorf("zstd: max window size %d out of range [%d, %d]", n, MinWindowSize, MaxWindowSize)
+		}
+		d.o.maxWindowSize = n
+		return nil
 	}
-	d.o.maxWindowSize = n
-	return nil
 }
 
-// SetMaxSize limits the total number of decompressed bytes produced.
+// WithDecoderMaxSize limits the total number of decompressed bytes produced.
 // The default, 0, disables the limit; a negative n is an error.
 //
 // For streaming ([Reader.Read] / [Reader.WriteTo]) the limit applies to the
@@ -63,49 +74,53 @@ func (d *Decoder) SetMaxWindowSize(n int) error {
 //
 // The limit is enforced per block, so output may exceed n by up to one block
 // (128 KiB) before an [ErrDecodedSizeExceeded] is returned.
-func (d *Decoder) SetMaxSize(n int64) error {
-	d.ensureInit()
-	if n < 0 {
-		return fmt.Errorf("zstd: max decoded size %d must be >= 0", n)
+func WithDecoderMaxSize(n int64) DecoderOption {
+	return func(d *Decoder) error {
+		if n < 0 {
+			return fmt.Errorf("zstd: max decoded size %d must be >= 0", n)
+		}
+		d.o.maxDecodedSize = n
+		return nil
 	}
-	d.o.maxDecodedSize = n
-	return nil
 }
 
-// AddDict registers a dictionary for decompression.
+// WithDecoderDict registers a dictionary for decompression.
 // Passing nil removes all previously registered dictionaries.
 // A non-nil Dict that was not created by [ParseDict] is ignored.
-func (d *Decoder) AddDict(pd *Dict) {
-	d.ensureInit()
-	if pd == nil || pd.d == nil {
-		if pd == nil {
-			clear(d.dicts)
-			return
+func WithDecoderDict(pd *Dict) DecoderOption {
+	return func(d *Decoder) error {
+		if pd == nil || pd.d == nil {
+			if pd == nil {
+				clear(d.dicts)
+			}
+			return nil
 		}
-		return
+		if d.dicts == nil {
+			d.dicts = make(map[uint32]*dict)
+		}
+		d.dicts[pd.d.id] = pd.d
+		return nil
 	}
-	if d.dicts == nil {
-		d.dicts = make(map[uint32]*dict)
-	}
-	d.dicts[pd.d.id] = pd.d
 }
 
-// SetRawDict registers raw bytes as a dictionary with ID 0.
+// WithDecoderRawDict registers raw bytes as a dictionary with ID 0.
 // The dictionary must be at least 8 bytes; shorter values are ignored.
 // Passing nil removes all previously registered dictionaries.
-func (d *Decoder) SetRawDict(b []byte) {
-	d.ensureInit()
-	if b == nil {
-		clear(d.dicts)
-		return
+func WithDecoderRawDict(b []byte) DecoderOption {
+	return func(d *Decoder) error {
+		if b == nil {
+			clear(d.dicts)
+			return nil
+		}
+		if len(b) < 8 {
+			return nil
+		}
+		if d.dicts == nil {
+			d.dicts = make(map[uint32]*dict)
+		}
+		d.dicts[0] = &dict{id: 0, content: b, offsets: [3]int{1, 4, 8}}
+		return nil
 	}
-	if len(b) < 8 {
-		return
-	}
-	if d.dicts == nil {
-		d.dicts = make(map[uint32]*dict)
-	}
-	d.dicts[0] = &dict{id: 0, content: b, offsets: [3]int{1, 4, 8}}
 }
 
 // AppendDecompress decompresses src and appends the decompressed bytes to dst,
@@ -119,10 +134,9 @@ func (d *Decoder) SetRawDict(b []byte) {
 //
 //	result, err := d.AppendDecompress(existingPrefix, compressed)
 //
-// Any registered dictionaries (via AddDict or SetRawDict) apply.
+// Any configured dictionaries (via WithDecoderDict or WithDecoderRawDict) apply.
 //
-// AppendDecompress is safe for concurrent use on the same Decoder,
-// provided configuration methods are not called concurrently.
+// AppendDecompress is safe for concurrent use on the same Decoder.
 func (d *Decoder) AppendDecompress(dst, src []byte) ([]byte, error) {
 	d.ensureInit()
 

--- a/decoder.go
+++ b/decoder.go
@@ -1,0 +1,181 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package zstd
+
+import (
+	"fmt"
+	"io"
+)
+
+var defaultDecoderOptions = decoderOptions{
+	maxWindowSize: 128 << 20,
+	lowMem:        true,
+}
+
+// Decoder holds decompression configuration and provides one-shot decompression
+// via [Decoder.AppendDecompress]. A single Decoder may be passed to any number
+// of [NewReader] calls; it must not be reconfigured while a bound Reader is
+// mid-stream.
+type Decoder struct {
+	o           decoderOptions
+	dicts       map[uint32]*dict
+	initialized bool
+}
+
+// ensureInit lazily applies default configuration on first use.
+func (d *Decoder) ensureInit() {
+	if d.initialized {
+		return
+	}
+	d.initialized = true
+	initPredefined()
+	d.o = defaultDecoderOptions
+}
+
+// NewDecoder returns a new Decoder configured with default limits.
+func NewDecoder() *Decoder {
+	d := &Decoder{}
+	d.ensureInit()
+	return d
+}
+
+// SetMaxWindowSize sets the maximum allowed window size for decoding.
+// The default is 128 MiB.
+//
+// n must be in the range [MinWindowSize, MaxWindowSize].
+func (d *Decoder) SetMaxWindowSize(n int) error {
+	d.ensureInit()
+	if n < MinWindowSize || n > MaxWindowSize {
+		return fmt.Errorf("zstd: max window size %d out of range [%d, %d]", n, MinWindowSize, MaxWindowSize)
+	}
+	d.o.maxWindowSize = n
+	return nil
+}
+
+// SetMaxSize limits the total number of decompressed bytes produced.
+// The default, 0, disables the limit; a negative n is an error.
+//
+// For streaming ([Reader.Read] / [Reader.WriteTo]) the limit applies to the
+// total output produced since the last [Reader.Reset]. For
+// [Decoder.AppendDecompress] it applies to the total output of a single call
+// (across any concatenated frames), excluding bytes already present in dst.
+//
+// The limit is enforced per block, so output may exceed n by up to one block
+// (128 KiB) before an [ErrDecodedSizeExceeded] is returned.
+func (d *Decoder) SetMaxSize(n int64) error {
+	d.ensureInit()
+	if n < 0 {
+		return fmt.Errorf("zstd: max decoded size %d must be >= 0", n)
+	}
+	d.o.maxDecodedSize = n
+	return nil
+}
+
+// AddDict registers a dictionary for decompression.
+// Passing nil removes all previously registered dictionaries.
+// A non-nil Dict that was not created by [ParseDict] is ignored.
+func (d *Decoder) AddDict(pd *Dict) {
+	d.ensureInit()
+	if pd == nil || pd.d == nil {
+		if pd == nil {
+			clear(d.dicts)
+			return
+		}
+		return
+	}
+	if d.dicts == nil {
+		d.dicts = make(map[uint32]*dict)
+	}
+	d.dicts[pd.d.id] = pd.d
+}
+
+// SetRawDict registers raw bytes as a dictionary with ID 0.
+// The dictionary must be at least 8 bytes; shorter values are ignored.
+// Passing nil removes all previously registered dictionaries.
+func (d *Decoder) SetRawDict(b []byte) {
+	d.ensureInit()
+	if b == nil {
+		clear(d.dicts)
+		return
+	}
+	if len(b) < 8 {
+		return
+	}
+	if d.dicts == nil {
+		d.dicts = make(map[uint32]*dict)
+	}
+	d.dicts[0] = &dict{id: 0, content: b, offsets: [3]int{1, 4, 8}}
+}
+
+// AppendDecompress decompresses src and appends the decompressed bytes to dst,
+// returning the extended buffer. It is a one-shot alternative to the streaming
+// [Reader] interface.
+//
+// src may contain one or more concatenated zstd frames.
+//
+// Passing nil for dst allocates a new slice. Passing a non-nil dst lets the
+// caller reuse memory or prepend existing data:
+//
+//	result, err := d.AppendDecompress(existingPrefix, compressed)
+//
+// Any registered dictionaries (via AddDict or SetRawDict) apply.
+//
+// AppendDecompress is safe for concurrent use on the same Decoder,
+// provided configuration methods are not called concurrently.
+func (d *Decoder) AppendDecompress(dst, src []byte) ([]byte, error) {
+	d.ensureInit()
+
+	frame, _ := frameDecPool.Get().(*frameDec)
+	if frame == nil {
+		frame = newFrameDec(d.o)
+	} else {
+		frame.o = d.o
+	}
+	block, _ := blockDecPool.Get().(*blockDec)
+	if block == nil {
+		block = &blockDec{lowMem: d.o.lowMem}
+	} else {
+		block.lowMem = d.o.lowMem
+	}
+	defer func() {
+		frameDecPool.Put(frame)
+		blockDecPool.Put(block)
+	}()
+
+	dstStart := len(dst)
+	frame.bBuf = byteBuf(src)
+	var frameSeen bool
+	for {
+		err := frame.reset(&frame.bBuf)
+		if err == io.EOF {
+			if !frameSeen {
+				return dst, &ErrCorrupted{msg: "empty input", err: io.ErrUnexpectedEOF}
+			}
+			return dst, nil
+		}
+		if err != nil {
+			return dst, err
+		}
+		frameSeen = true
+		frame.history.reset()
+
+		if frame.DictionaryID != 0 {
+			dd, ok := d.dicts[frame.DictionaryID]
+			if !ok {
+				return dst, ErrUnknownDictionary
+			}
+			frame.history.setDict(dd)
+		} else if dd, ok := d.dicts[0]; ok {
+			frame.history.dict = dd
+			frame.history.decoders.dict = dd.content
+		}
+
+		var err2 error
+		dst, err2 = frame.runDecoder(dst, block, d.o.maxDecodedSize, dstStart)
+		if err2 != nil {
+			return dst, err2
+		}
+	}
+}

--- a/decoder.go
+++ b/decoder.go
@@ -179,15 +179,8 @@ func (d *Decoder) AppendDecompress(dst, src []byte) ([]byte, error) {
 		frameSeen = true
 		frame.history.reset()
 
-		if frame.DictionaryID != 0 {
-			dd, ok := d.dicts[frame.DictionaryID]
-			if !ok {
-				return dst, ErrUnknownDictionary
-			}
-			frame.history.setDict(dd)
-		} else if dd, ok := d.dicts[0]; ok {
-			frame.history.dict = dd
-			frame.history.decoders.dict = dd.content
+		if err := applyFrameDict(frame, d.dicts); err != nil {
+			return dst, err
 		}
 
 		var err2 error

--- a/decoder.go
+++ b/decoder.go
@@ -7,6 +7,7 @@ package zstd
 import (
 	"fmt"
 	"io"
+	"sync"
 )
 
 var defaultDecoderOptions = decoderOptions{
@@ -19,19 +20,17 @@ var defaultDecoderOptions = decoderOptions{
 // of [NewReader] calls; it must not be reconfigured while a bound Reader is
 // mid-stream.
 type Decoder struct {
-	o           decoderOptions
-	dicts       map[uint32]*dict
-	initialized bool
+	o     decoderOptions
+	dicts map[uint32]*dict
+	once  sync.Once
 }
 
 // ensureInit lazily applies default configuration on first use.
 func (d *Decoder) ensureInit() {
-	if d.initialized {
-		return
-	}
-	d.initialized = true
-	initPredefined()
-	d.o = defaultDecoderOptions
+	d.once.Do(func() {
+		initPredefined()
+		d.o = defaultDecoderOptions
+	})
 }
 
 // NewDecoder returns a new Decoder configured with default limits.
@@ -140,6 +139,10 @@ func (d *Decoder) AppendDecompress(dst, src []byte) ([]byte, error) {
 		block.lowMem = d.o.lowMem
 	}
 	defer func() {
+		// Drop references to the caller's src and dst so the pool does not pin
+		// caller-owned buffers between decodes.
+		frame.bBuf = nil
+		frame.history.b = nil
 		frameDecPool.Put(frame)
 		blockDecPool.Put(block)
 	}()

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package zstd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestZeroValueReaderAppendCompress(t *testing.T) {
+	frame := buildRawFrame([]byte("decode zero"))
+	var d Decoder
+	got, err := d.AppendDecompress(nil, frame)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "decode zero" {
+		t.Fatalf("got %q, want %q", got, "decode zero")
+	}
+}
+
+func TestAppendDecompressConcurrent(t *testing.T) {
+	src := bytes.Repeat([]byte("concurrent decompress test data! "), 500)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
+
+	d := NewDecoder()
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			got, err := d.AppendDecompress(nil, compressed)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !bytes.Equal(got, src) {
+				errs <- bytes.ErrTooLarge
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}
+
+func TestAppendDecompressEmpty(t *testing.T) {
+	var d Decoder
+	for _, src := range [][]byte{nil, {}} {
+		_, err := d.AppendDecompress(nil, src)
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted for %v, got %v", src, err)
+		}
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("expected io.ErrUnexpectedEOF wrapped for %v, got %v", src, err)
+		}
+	}
+}
+
+func TestSetMaxSizeValidation(t *testing.T) {
+	d := NewDecoder()
+	if err := d.SetMaxSize(-1); err == nil {
+		t.Fatal("expected error for -1")
+	}
+	if err := d.SetMaxSize(0); err != nil {
+		t.Fatalf("0 must disable the limit: %v", err)
+	}
+	if err := d.SetMaxSize(100); err != nil {
+		t.Fatalf("positive limit must be valid: %v", err)
+	}
+}
+
+// TestSetMaxSizeAppendDecompress covers the declared-size early rejection (frames
+// from AppendCompress carry FrameContentSize), the exact-limit boundary, dst
+// prefix exclusion, and disabling.
+func TestSetMaxSizeAppendDecompress(t *testing.T) {
+	src := bytes.Repeat([]byte("bomb "), 1000)
+	compressed := NewEncoder().AppendCompress(nil, src)
+
+	d := NewDecoder()
+	if err := d.SetMaxSize(int64(len(src)) - 1); err != nil {
+		t.Fatal(err)
+	}
+	_, err := d.AppendDecompress(nil, compressed)
+	var de *ErrDecodedSizeExceeded
+	if !errors.As(err, &de) {
+		t.Fatalf("expected ErrDecodedSizeExceeded, got %v", err)
+	}
+	if de.Allowed != int64(len(src))-1 {
+		t.Fatalf("Allowed = %d, want %d", de.Allowed, int64(len(src))-1)
+	}
+	// A resource-limit error is not stream corruption.
+	if errors.Is(err, &ErrCorrupted{}) {
+		t.Fatal("ErrDecodedSizeExceeded must not match ErrCorrupted")
+	}
+
+	// Exactly the limit succeeds.
+	if err := d.SetMaxSize(int64(len(src))); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.AppendDecompress(nil, compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch")
+	}
+
+	// The caller's existing dst prefix must not count against the budget.
+	prefix := []byte("prefix-not-counted")
+	got, err = d.AppendDecompress(prefix, compressed)
+	if err != nil {
+		t.Fatalf("dst prefix must be excluded from the limit: %v", err)
+	}
+	want := append(append([]byte{}, prefix...), src...)
+	if !bytes.Equal(got, want) {
+		t.Fatal("prefix mismatch")
+	}
+
+	// Disabling restores unlimited decoding.
+	if err := d.SetMaxSize(0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.AppendDecompress(nil, compressed); err != nil {
+		t.Fatalf("limit disabled: %v", err)
+	}
+}
+
+// TestSetMaxSizeAppendDecompressNoContentSize covers the mid-decode guard: a
+// multi-block streamed frame omits FrameContentSize, so the limit must be
+// enforced while blocks are decoded, not only from the declared size.
+func TestSetMaxSizeAppendDecompressNoContentSize(t *testing.T) {
+	src := bytes.Repeat([]byte("no fcs bomb "), 40000) // multi-block, no FrameContentSize
+	var buf bytes.Buffer
+	w := NewWriter(&buf, nil)
+	if _, err := w.Write(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	compressed := buf.Bytes()
+
+	d := NewDecoder()
+	if err := d.SetMaxSize(int64(len(src)) / 2); err != nil {
+		t.Fatal(err)
+	}
+	_, err := d.AppendDecompress(nil, compressed)
+	var de *ErrDecodedSizeExceeded
+	if !errors.As(err, &de) {
+		t.Fatalf("expected ErrDecodedSizeExceeded from mid-decode guard, got %v", err)
+	}
+
+	// Without a limit the same frame decodes fully.
+	if err := d.SetMaxSize(0); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.AppendDecompress(nil, compressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch")
+	}
+}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -41,7 +41,7 @@ func TestDecoder_AppendDecompress(t *testing.T) {
 
 	t.Run("pre_existing_dst", func(t *testing.T) {
 		src := []byte("appended after prefix")
-		e := NewEncoder()
+		e := mustEncoder(t)
 		compressed := e.AppendCompress(nil, src)
 
 		var d Decoder
@@ -61,7 +61,7 @@ func TestDecoder_AppendDecompress(t *testing.T) {
 		src := make([]byte, 1<<20+50000)
 		rng.Read(src)
 
-		e := NewEncoder()
+		e := mustEncoder(t)
 		compressed := e.AppendCompress(nil, src)
 
 		var d Decoder
@@ -75,8 +75,7 @@ func TestDecoder_AppendDecompress(t *testing.T) {
 	})
 
 	t.Run("multi_frame_crc", func(t *testing.T) {
-		e := NewEncoder()
-		e.SetCRC(true)
+		e := mustEncoder(t, WithEncoderCRC(true))
 		frame1 := e.AppendCompress(nil, []byte("frame one "))
 		frame2 := e.AppendCompress(nil, []byte("frame two"))
 		combined := append(frame1, frame2...)
@@ -95,10 +94,10 @@ func TestDecoder_AppendDecompress(t *testing.T) {
 func TestDecoder_AppendDecompress_Concurrent(t *testing.T) {
 	t.Run("same_decoder", func(t *testing.T) {
 		src := bytes.Repeat([]byte("concurrent decompress test data! "), 500)
-		e := NewEncoder()
+		e := mustEncoder(t)
 		compressed := e.AppendCompress(nil, src)
 
-		d := NewDecoder()
+		d := mustDecoder(t)
 
 		const goroutines = 8
 		var wg sync.WaitGroup
@@ -126,8 +125,8 @@ func TestDecoder_AppendDecompress_Concurrent(t *testing.T) {
 	})
 
 	t.Run("different_data", func(t *testing.T) {
-		e := NewEncoder()
-		d := NewDecoder()
+		e := mustEncoder(t)
+		d := mustDecoder(t)
 
 		const goroutines = 8
 		var wg sync.WaitGroup
@@ -158,7 +157,7 @@ func TestDecoder_AppendDecompress_Concurrent(t *testing.T) {
 
 	t.Run("zero_value", func(t *testing.T) {
 		src := bytes.Repeat([]byte("zero value concurrent decode "), 200)
-		compressed := NewEncoder().AppendCompress(nil, src)
+		compressed := mustEncoder(t).AppendCompress(nil, src)
 		var d Decoder
 
 		const goroutines = 8
@@ -187,18 +186,13 @@ func TestDecoder_AppendDecompress_Concurrent(t *testing.T) {
 	})
 }
 
-func TestDecoder_SetMaxSize(t *testing.T) {
+func TestWithDecoderMaxSize(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
-		d := NewDecoder()
-		if err := d.SetMaxSize(-1); err == nil {
+		if _, err := NewDecoder(WithDecoderMaxSize(-1)); err == nil {
 			t.Fatal("expected error for -1")
 		}
-		if err := d.SetMaxSize(0); err != nil {
-			t.Fatalf("0 must disable the limit: %v", err)
-		}
-		if err := d.SetMaxSize(100); err != nil {
-			t.Fatalf("positive limit must be valid: %v", err)
-		}
+		mustDecoder(t, WithDecoderMaxSize(0))
+		mustDecoder(t, WithDecoderMaxSize(100))
 	})
 
 	// append_decompress covers the declared-size early rejection (frames from
@@ -206,12 +200,9 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 	// prefix exclusion, and disabling.
 	t.Run("append_decompress", func(t *testing.T) {
 		src := bytes.Repeat([]byte("bomb "), 1000)
-		compressed := NewEncoder().AppendCompress(nil, src)
+		compressed := mustEncoder(t).AppendCompress(nil, src)
 
-		d := NewDecoder()
-		if err := d.SetMaxSize(int64(len(src)) - 1); err != nil {
-			t.Fatal(err)
-		}
+		d := mustDecoder(t, WithDecoderMaxSize(int64(len(src))-1))
 		_, err := d.AppendDecompress(nil, compressed)
 		var de *ErrDecodedSizeExceeded
 		if !errors.As(err, &de) {
@@ -226,9 +217,7 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 		}
 
 		// Exactly the limit succeeds.
-		if err := d.SetMaxSize(int64(len(src))); err != nil {
-			t.Fatal(err)
-		}
+		d = mustDecoder(t, WithDecoderMaxSize(int64(len(src))))
 		got, err := d.AppendDecompress(nil, compressed)
 		if err != nil {
 			t.Fatal(err)
@@ -249,9 +238,7 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 		}
 
 		// Disabling restores unlimited decoding.
-		if err := d.SetMaxSize(0); err != nil {
-			t.Fatal(err)
-		}
+		d = mustDecoder(t, WithDecoderMaxSize(0))
 		if _, err := d.AppendDecompress(nil, compressed); err != nil {
 			t.Fatalf("limit disabled: %v", err)
 		}
@@ -263,7 +250,7 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 	t.Run("no_content_size", func(t *testing.T) {
 		src := bytes.Repeat([]byte("no fcs bomb "), 40000) // multi-block, no FrameContentSize
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
 		}
@@ -272,10 +259,7 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 		}
 		compressed := buf.Bytes()
 
-		d := NewDecoder()
-		if err := d.SetMaxSize(int64(len(src)) / 2); err != nil {
-			t.Fatal(err)
-		}
+		d := mustDecoder(t, WithDecoderMaxSize(int64(len(src))/2))
 		_, err := d.AppendDecompress(nil, compressed)
 		var de *ErrDecodedSizeExceeded
 		if !errors.As(err, &de) {
@@ -283,9 +267,7 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 		}
 
 		// Without a limit the same frame decodes fully.
-		if err := d.SetMaxSize(0); err != nil {
-			t.Fatal(err)
-		}
+		d = mustDecoder(t, WithDecoderMaxSize(0))
 		got, err := d.AppendDecompress(nil, compressed)
 		if err != nil {
 			t.Fatal(err)
@@ -299,16 +281,13 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 	// within a single AppendDecompress call.
 	t.Run("multi_frame", func(t *testing.T) {
 		part := bytes.Repeat([]byte("frame "), 500)
-		e := NewEncoder()
+		e := mustEncoder(t)
 		var concatenated []byte
 		concatenated = e.AppendCompress(concatenated, part)
 		concatenated = e.AppendCompress(concatenated, part)
 
-		d := NewDecoder()
 		// Enough for one frame but not both.
-		if err := d.SetMaxSize(int64(len(part)) + 100); err != nil {
-			t.Fatal(err)
-		}
+		d := mustDecoder(t, WithDecoderMaxSize(int64(len(part))+100))
 		_, err := d.AppendDecompress(nil, concatenated)
 		var de *ErrDecodedSizeExceeded
 		if !errors.As(err, &de) {
@@ -316,9 +295,7 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 		}
 
 		// Enough for both frames succeeds.
-		if err := d.SetMaxSize(int64(2 * len(part))); err != nil {
-			t.Fatal(err)
-		}
+		d = mustDecoder(t, WithDecoderMaxSize(int64(2*len(part))))
 		got, err := d.AppendDecompress(nil, concatenated)
 		if err != nil {
 			t.Fatal(err)
@@ -330,31 +307,23 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 	})
 }
 
-func TestDecoder_SetMaxWindowSize(t *testing.T) {
+func TestWithDecoderMaxWindow(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
-		d := NewDecoder()
-		if err := d.SetMaxWindowSize(0); err == nil {
+		if _, err := NewDecoder(WithDecoderMaxWindow(0)); err == nil {
 			t.Fatal("expected error for 0")
 		}
-		if err := d.SetMaxWindowSize(-1); err == nil {
+		if _, err := NewDecoder(WithDecoderMaxWindow(-1)); err == nil {
 			t.Fatal("expected error for -1")
 		}
-		if err := d.SetMaxWindowSize(MaxWindowSize + 1); err == nil {
+		if _, err := NewDecoder(WithDecoderMaxWindow(MaxWindowSize + 1)); err == nil {
 			t.Fatal("expected error for too large")
 		}
-		if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
-			t.Fatalf("MinWindowSize should be valid: %v", err)
-		}
-		if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
-			t.Fatalf("MaxWindowSize should be valid: %v", err)
-		}
+		mustDecoder(t, WithDecoderMaxWindow(MinWindowSize))
+		mustDecoder(t, WithDecoderMaxWindow(MaxWindowSize))
 	})
 
 	t.Run("one_shot", func(t *testing.T) {
-		d := NewDecoder()
-		if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
-			t.Fatal(err)
-		}
+		d := mustDecoder(t, WithDecoderMaxWindow(MaxWindowSize))
 		frame := buildRawFrame([]byte("config"))
 		got, err := d.AppendDecompress(nil, frame)
 		if err != nil {
@@ -367,15 +336,14 @@ func TestDecoder_SetMaxWindowSize(t *testing.T) {
 }
 
 func TestDecoderReuseAcrossReaders(t *testing.T) {
-	e := NewEncoder()
+	e := mustEncoder(t)
 	uno := bytes.Repeat([]byte("uno "), 300)
 	dos := bytes.Repeat([]byte("dos "), 300)
 	f1 := e.AppendCompress(nil, uno)
 	f2 := e.AppendCompress(nil, dos)
 
-	d := NewDecoder()
 	for _, tc := range []struct{ frame, want []byte }{{f1, uno}, {f2, dos}} {
-		r := NewReader(bytes.NewReader(tc.frame), d)
+		r := mustReader(t, bytes.NewReader(tc.frame))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -387,15 +355,14 @@ func TestDecoderReuseAcrossReaders(t *testing.T) {
 	}
 }
 
-// TestDecoderReconfigureBetweenStreams tightens then loosens the max window on a
-// bound Decoder between Reset cycles and verifies the new limit is honored.
+// TestDecoderReconfigureBetweenStreams verifies the max-window limit is honored
+// per reader: a tiny window rejects a wide frame while a large window accepts it.
+// The window is now fixed at construction, so each phase uses a fresh reader.
 func TestDecoderReconfigureBetweenStreams(t *testing.T) {
 	src := bytes.Repeat([]byte("decoder reconfigure "), 300)
-	compressed := NewEncoder().AppendCompress(nil, src)
+	compressed := mustEncoder(t).AppendCompress(nil, src)
 
-	d := NewDecoder()
-	r := NewReader(bytes.NewReader(compressed), d)
-
+	r := mustReader(t, bytes.NewReader(compressed))
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -404,26 +371,16 @@ func TestDecoderReconfigureBetweenStreams(t *testing.T) {
 		t.Fatal("mismatch")
 	}
 
-	// Tighten the SAME decoder, reuse the SAME reader: must now fail.
-	if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
-		t.Fatal(err)
-	}
+	// A fresh reader with a tiny window must now fail.
+	r = mustReader(t, bytes.NewReader(compressed), WithDecoderMaxWindow(MinWindowSize))
 	_, err = io.ReadAll(r)
 	var we *ErrWindowSizeExceeded
 	if !errors.As(err, &we) {
 		t.Fatalf("expected ErrWindowSizeExceeded after tightening, got %v", err)
 	}
 
-	// Loosen again: succeeds.
-	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
-		t.Fatal(err)
-	}
+	// A fresh reader with a large window succeeds.
+	r = mustReader(t, bytes.NewReader(compressed), WithDecoderMaxWindow(MaxWindowSize))
 	got, err = io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -8,11 +8,12 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"math/rand"
 	"sync"
 	"testing"
 )
 
-func TestZeroValueReaderAppendCompress(t *testing.T) {
+func TestDecoder_ZeroValue(t *testing.T) {
 	frame := buildRawFrame([]byte("decode zero"))
 	var d Decoder
 	got, err := d.AppendDecompress(nil, frame)
@@ -24,93 +25,348 @@ func TestZeroValueReaderAppendCompress(t *testing.T) {
 	}
 }
 
-func TestAppendDecompressConcurrent(t *testing.T) {
-	src := bytes.Repeat([]byte("concurrent decompress test data! "), 500)
+func TestDecoder_AppendDecompress(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		var d Decoder
+		for _, src := range [][]byte{nil, {}} {
+			_, err := d.AppendDecompress(nil, src)
+			if !errors.Is(err, &ErrCorrupted{}) {
+				t.Fatalf("expected ErrCorrupted for %v, got %v", src, err)
+			}
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("expected io.ErrUnexpectedEOF wrapped for %v, got %v", src, err)
+			}
+		}
+	})
+
+	t.Run("pre_existing_dst", func(t *testing.T) {
+		src := []byte("appended after prefix")
+		e := NewEncoder()
+		compressed := e.AppendCompress(nil, src)
+
+		var d Decoder
+		prefix := []byte("PREFIX:")
+		got, err := d.AppendDecompress(prefix, compressed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "PREFIX:appended after prefix" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("large", func(t *testing.T) {
+		// > 1 MiB to exercise the non-prealloc path in runDecoder.
+		rng := rand.New(rand.NewSource(99))
+		src := make([]byte, 1<<20+50000)
+		rng.Read(src)
+
+		e := NewEncoder()
+		compressed := e.AppendCompress(nil, src)
+
+		var d Decoder
+		got, err := d.AppendDecompress(nil, compressed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("multi_frame_crc", func(t *testing.T) {
+		e := NewEncoder()
+		e.SetCRC(true)
+		frame1 := e.AppendCompress(nil, []byte("frame one "))
+		frame2 := e.AppendCompress(nil, []byte("frame two"))
+		combined := append(frame1, frame2...)
+
+		var d Decoder
+		got, err := d.AppendDecompress(nil, combined)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "frame one frame two" {
+			t.Fatalf("got %q", got)
+		}
+	})
+}
+
+func TestDecoder_AppendDecompress_Concurrent(t *testing.T) {
+	t.Run("same_decoder", func(t *testing.T) {
+		src := bytes.Repeat([]byte("concurrent decompress test data! "), 500)
+		e := NewEncoder()
+		compressed := e.AppendCompress(nil, src)
+
+		d := NewDecoder()
+
+		const goroutines = 8
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		errs := make(chan error, goroutines)
+
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				got, err := d.AppendDecompress(nil, compressed)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(got, src) {
+					errs <- bytes.ErrTooLarge
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("different_data", func(t *testing.T) {
+		e := NewEncoder()
+		d := NewDecoder()
+
+		const goroutines = 8
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		errs := make(chan error, goroutines)
+
+		for i := range goroutines {
+			src := bytes.Repeat([]byte{byte('A' + i)}, 5000)
+			compressed := e.AppendCompress(nil, src)
+			go func() {
+				defer wg.Done()
+				got, err := d.AppendDecompress(nil, compressed)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(got, src) {
+					errs <- errors.New("mismatch")
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestDecoder_SetMaxSize(t *testing.T) {
+	t.Run("validation", func(t *testing.T) {
+		d := NewDecoder()
+		if err := d.SetMaxSize(-1); err == nil {
+			t.Fatal("expected error for -1")
+		}
+		if err := d.SetMaxSize(0); err != nil {
+			t.Fatalf("0 must disable the limit: %v", err)
+		}
+		if err := d.SetMaxSize(100); err != nil {
+			t.Fatalf("positive limit must be valid: %v", err)
+		}
+	})
+
+	// append_decompress covers the declared-size early rejection (frames from
+	// AppendCompress carry FrameContentSize), the exact-limit boundary, dst
+	// prefix exclusion, and disabling.
+	t.Run("append_decompress", func(t *testing.T) {
+		src := bytes.Repeat([]byte("bomb "), 1000)
+		compressed := NewEncoder().AppendCompress(nil, src)
+
+		d := NewDecoder()
+		if err := d.SetMaxSize(int64(len(src)) - 1); err != nil {
+			t.Fatal(err)
+		}
+		_, err := d.AppendDecompress(nil, compressed)
+		var de *ErrDecodedSizeExceeded
+		if !errors.As(err, &de) {
+			t.Fatalf("expected ErrDecodedSizeExceeded, got %v", err)
+		}
+		if de.Allowed != int64(len(src))-1 {
+			t.Fatalf("Allowed = %d, want %d", de.Allowed, int64(len(src))-1)
+		}
+		// A resource-limit error is not stream corruption.
+		if errors.Is(err, &ErrCorrupted{}) {
+			t.Fatal("ErrDecodedSizeExceeded must not match ErrCorrupted")
+		}
+
+		// Exactly the limit succeeds.
+		if err := d.SetMaxSize(int64(len(src))); err != nil {
+			t.Fatal(err)
+		}
+		got, err := d.AppendDecompress(nil, compressed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+
+		// The caller's existing dst prefix must not count against the budget.
+		prefix := []byte("prefix-not-counted")
+		got, err = d.AppendDecompress(prefix, compressed)
+		if err != nil {
+			t.Fatalf("dst prefix must be excluded from the limit: %v", err)
+		}
+		want := append(append([]byte{}, prefix...), src...)
+		if !bytes.Equal(got, want) {
+			t.Fatal("prefix mismatch")
+		}
+
+		// Disabling restores unlimited decoding.
+		if err := d.SetMaxSize(0); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := d.AppendDecompress(nil, compressed); err != nil {
+			t.Fatalf("limit disabled: %v", err)
+		}
+	})
+
+	// no_content_size covers the mid-decode guard: a multi-block streamed frame
+	// omits FrameContentSize, so the limit must be enforced while blocks are
+	// decoded, not only from the declared size.
+	t.Run("no_content_size", func(t *testing.T) {
+		src := bytes.Repeat([]byte("no fcs bomb "), 40000) // multi-block, no FrameContentSize
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		compressed := buf.Bytes()
+
+		d := NewDecoder()
+		if err := d.SetMaxSize(int64(len(src)) / 2); err != nil {
+			t.Fatal(err)
+		}
+		_, err := d.AppendDecompress(nil, compressed)
+		var de *ErrDecodedSizeExceeded
+		if !errors.As(err, &de) {
+			t.Fatalf("expected ErrDecodedSizeExceeded from mid-decode guard, got %v", err)
+		}
+
+		// Without a limit the same frame decodes fully.
+		if err := d.SetMaxSize(0); err != nil {
+			t.Fatal(err)
+		}
+		got, err := d.AppendDecompress(nil, compressed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	// multi_frame verifies the limit is cumulative across concatenated frames
+	// within a single AppendDecompress call.
+	t.Run("multi_frame", func(t *testing.T) {
+		part := bytes.Repeat([]byte("frame "), 500)
+		e := NewEncoder()
+		var concatenated []byte
+		concatenated = e.AppendCompress(concatenated, part)
+		concatenated = e.AppendCompress(concatenated, part)
+
+		d := NewDecoder()
+		// Enough for one frame but not both.
+		if err := d.SetMaxSize(int64(len(part)) + 100); err != nil {
+			t.Fatal(err)
+		}
+		_, err := d.AppendDecompress(nil, concatenated)
+		var de *ErrDecodedSizeExceeded
+		if !errors.As(err, &de) {
+			t.Fatalf("expected cumulative ErrDecodedSizeExceeded, got %v", err)
+		}
+
+		// Enough for both frames succeeds.
+		if err := d.SetMaxSize(int64(2 * len(part))); err != nil {
+			t.Fatal(err)
+		}
+		got, err := d.AppendDecompress(nil, concatenated)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := append(append([]byte{}, part...), part...)
+		if !bytes.Equal(got, want) {
+			t.Fatal("mismatch")
+		}
+	})
+}
+
+func TestDecoder_SetMaxWindowSize(t *testing.T) {
+	t.Run("validation", func(t *testing.T) {
+		d := NewDecoder()
+		if err := d.SetMaxWindowSize(0); err == nil {
+			t.Fatal("expected error for 0")
+		}
+		if err := d.SetMaxWindowSize(-1); err == nil {
+			t.Fatal("expected error for -1")
+		}
+		if err := d.SetMaxWindowSize(MaxWindowSize + 1); err == nil {
+			t.Fatal("expected error for too large")
+		}
+		if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
+			t.Fatalf("MinWindowSize should be valid: %v", err)
+		}
+		if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
+			t.Fatalf("MaxWindowSize should be valid: %v", err)
+		}
+	})
+
+	t.Run("one_shot", func(t *testing.T) {
+		d := NewDecoder()
+		if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
+			t.Fatal(err)
+		}
+		frame := buildRawFrame([]byte("config"))
+		got, err := d.AppendDecompress(nil, frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "config" {
+			t.Fatalf("got %q", got)
+		}
+	})
+}
+
+func TestDecoderReuseAcrossReaders(t *testing.T) {
 	e := NewEncoder()
-	compressed := e.AppendCompress(nil, src)
+	uno := bytes.Repeat([]byte("uno "), 300)
+	dos := bytes.Repeat([]byte("dos "), 300)
+	f1 := e.AppendCompress(nil, uno)
+	f2 := e.AppendCompress(nil, dos)
 
 	d := NewDecoder()
-
-	const goroutines = 8
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	errs := make(chan error, goroutines)
-
-	for range goroutines {
-		go func() {
-			defer wg.Done()
-			got, err := d.AppendDecompress(nil, compressed)
-			if err != nil {
-				errs <- err
-				return
-			}
-			if !bytes.Equal(got, src) {
-				errs <- bytes.ErrTooLarge
-			}
-		}()
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Fatal(err)
-	}
-}
-
-func TestAppendDecompressEmpty(t *testing.T) {
-	var d Decoder
-	for _, src := range [][]byte{nil, {}} {
-		_, err := d.AppendDecompress(nil, src)
-		if !errors.Is(err, &ErrCorrupted{}) {
-			t.Fatalf("expected ErrCorrupted for %v, got %v", src, err)
+	for _, tc := range []struct{ frame, want []byte }{{f1, uno}, {f2, dos}} {
+		r := NewReader(bytes.NewReader(tc.frame), d)
+		got, err := io.ReadAll(r)
+		_ = r.Close()
+		if err != nil {
+			t.Fatal(err)
 		}
-		if !errors.Is(err, io.ErrUnexpectedEOF) {
-			t.Fatalf("expected io.ErrUnexpectedEOF wrapped for %v, got %v", src, err)
+		if !bytes.Equal(got, tc.want) {
+			t.Fatal("mismatch")
 		}
 	}
 }
 
-func TestSetMaxSizeValidation(t *testing.T) {
-	d := NewDecoder()
-	if err := d.SetMaxSize(-1); err == nil {
-		t.Fatal("expected error for -1")
-	}
-	if err := d.SetMaxSize(0); err != nil {
-		t.Fatalf("0 must disable the limit: %v", err)
-	}
-	if err := d.SetMaxSize(100); err != nil {
-		t.Fatalf("positive limit must be valid: %v", err)
-	}
-}
-
-// TestSetMaxSizeAppendDecompress covers the declared-size early rejection (frames
-// from AppendCompress carry FrameContentSize), the exact-limit boundary, dst
-// prefix exclusion, and disabling.
-func TestSetMaxSizeAppendDecompress(t *testing.T) {
-	src := bytes.Repeat([]byte("bomb "), 1000)
+// TestDecoderReconfigureBetweenStreams tightens then loosens the max window on a
+// bound Decoder between Reset cycles and verifies the new limit is honored.
+func TestDecoderReconfigureBetweenStreams(t *testing.T) {
+	src := bytes.Repeat([]byte("decoder reconfigure "), 300)
 	compressed := NewEncoder().AppendCompress(nil, src)
 
 	d := NewDecoder()
-	if err := d.SetMaxSize(int64(len(src)) - 1); err != nil {
-		t.Fatal(err)
-	}
-	_, err := d.AppendDecompress(nil, compressed)
-	var de *ErrDecodedSizeExceeded
-	if !errors.As(err, &de) {
-		t.Fatalf("expected ErrDecodedSizeExceeded, got %v", err)
-	}
-	if de.Allowed != int64(len(src))-1 {
-		t.Fatalf("Allowed = %d, want %d", de.Allowed, int64(len(src))-1)
-	}
-	// A resource-limit error is not stream corruption.
-	if errors.Is(err, &ErrCorrupted{}) {
-		t.Fatal("ErrDecodedSizeExceeded must not match ErrCorrupted")
-	}
+	r := NewReader(bytes.NewReader(compressed), d)
 
-	// Exactly the limit succeeds.
-	if err := d.SetMaxSize(int64(len(src))); err != nil {
-		t.Fatal(err)
-	}
-	got, err := d.AppendDecompress(nil, compressed)
+	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,56 +374,28 @@ func TestSetMaxSizeAppendDecompress(t *testing.T) {
 		t.Fatal("mismatch")
 	}
 
-	// The caller's existing dst prefix must not count against the budget.
-	prefix := []byte("prefix-not-counted")
-	got, err = d.AppendDecompress(prefix, compressed)
-	if err != nil {
-		t.Fatalf("dst prefix must be excluded from the limit: %v", err)
+	// Tighten the SAME decoder, reuse the SAME reader: must now fail.
+	if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
+		t.Fatal(err)
 	}
-	want := append(append([]byte{}, prefix...), src...)
-	if !bytes.Equal(got, want) {
-		t.Fatal("prefix mismatch")
+	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(r)
+	var we *ErrWindowSizeExceeded
+	if !errors.As(err, &we) {
+		t.Fatalf("expected ErrWindowSizeExceeded after tightening, got %v", err)
 	}
 
-	// Disabling restores unlimited decoding.
-	if err := d.SetMaxSize(0); err != nil {
+	// Loosen again: succeeds.
+	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := d.AppendDecompress(nil, compressed); err != nil {
-		t.Fatalf("limit disabled: %v", err)
-	}
-}
-
-// TestSetMaxSizeAppendDecompressNoContentSize covers the mid-decode guard: a
-// multi-block streamed frame omits FrameContentSize, so the limit must be
-// enforced while blocks are decoded, not only from the declared size.
-func TestSetMaxSizeAppendDecompressNoContentSize(t *testing.T) {
-	src := bytes.Repeat([]byte("no fcs bomb "), 40000) // multi-block, no FrameContentSize
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	if _, err := w.Write(src); err != nil {
+	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-	compressed := buf.Bytes()
-
-	d := NewDecoder()
-	if err := d.SetMaxSize(int64(len(src)) / 2); err != nil {
-		t.Fatal(err)
-	}
-	_, err := d.AppendDecompress(nil, compressed)
-	var de *ErrDecodedSizeExceeded
-	if !errors.As(err, &de) {
-		t.Fatalf("expected ErrDecodedSizeExceeded from mid-decode guard, got %v", err)
-	}
-
-	// Without a limit the same frame decodes fully.
-	if err := d.SetMaxSize(0); err != nil {
-		t.Fatal(err)
-	}
-	got, err := d.AppendDecompress(nil, compressed)
+	got, err = io.ReadAll(r)
+	_ = r.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -155,6 +155,36 @@ func TestDecoder_AppendDecompress_Concurrent(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("zero_value", func(t *testing.T) {
+		src := bytes.Repeat([]byte("zero value concurrent decode "), 200)
+		compressed := NewEncoder().AppendCompress(nil, src)
+		var d Decoder
+
+		const goroutines = 8
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		errs := make(chan error, goroutines)
+
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				got, err := d.AppendDecompress(nil, compressed)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(got, src) {
+					errs <- bytes.ErrTooLarge
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestDecoder_SetMaxSize(t *testing.T) {

--- a/dict_test.go
+++ b/dict_test.go
@@ -14,24 +14,207 @@ import (
 	"testing"
 )
 
-func TestParseDictErrors(t *testing.T) {
-	// Empty input.
-	if _, err := ParseDict(nil); err == nil {
-		t.Fatal("expected error for nil input")
+func loadTestDict(t *testing.T) []byte {
+	t.Helper()
+	b, err := os.ReadFile("testdata/d0.dict")
+	if err != nil {
+		t.Fatal(err)
 	}
-	// Too short.
-	if _, err := ParseDict(make([]byte, 10)); err == nil {
-		t.Fatal("expected error for short input")
-	}
-	// Wrong magic.
-	bad := make([]byte, 100)
-	bad[0], bad[1], bad[2], bad[3] = 0x00, 0x00, 0x00, 0x00
-	if _, err := ParseDict(bad); !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
+	return b
 }
 
-func TestDictNilSafety(t *testing.T) {
+func TestParseDict(t *testing.T) {
+	t.Run("format", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.ID() == 0 {
+			t.Fatal("expected non-zero dict ID")
+		}
+		if !bytes.Equal(d.Bytes(), raw) {
+			t.Fatal("Bytes() != input")
+		}
+		if d.d.litEnc == nil {
+			t.Fatal("litEnc is nil")
+		}
+		for i, off := range d.d.offsets {
+			if off <= 0 {
+				t.Fatalf("offset[%d] = %d, want > 0", i, off)
+			}
+		}
+		if len(d.d.content) == 0 {
+			t.Fatal("content is empty")
+		}
+	})
+
+	t.Run("offsets_not_default", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, off := range d.d.offsets {
+			if off <= 0 {
+				t.Fatalf("offset[%d] = %d, want > 0", i, off)
+			}
+			if off > len(d.d.content) {
+				t.Fatalf("offset[%d] = %d, exceeds content length %d", i, off, len(d.d.content))
+			}
+		}
+	})
+
+	t.Run("content_size", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(d.d.content) == 0 {
+			t.Fatal("content is empty")
+		}
+		if len(d.d.content) >= len(raw) {
+			t.Fatalf("content (%d) should be smaller than raw (%d)", len(d.d.content), len(raw))
+		}
+	})
+
+	t.Run("id_frame_encoding", func(t *testing.T) {
+		raw := loadTestDict(t)
+		src := bytes.Repeat([]byte("dict id frame encoding "), 50)
+
+		// Test different ID ranges: 1-byte (<256), 2-byte (<65536), 4-byte (>=65536).
+		ids := []uint32{1, 200, 60000, 100000}
+		for _, id := range ids {
+			t.Run("", func(t *testing.T) {
+				b := append([]byte{}, raw...)
+				binary.LittleEndian.PutUint32(b[4:8], id)
+				d, err := ParseDict(b)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if d.ID() != id {
+					t.Fatalf("ID: got %d, want %d", d.ID(), id)
+				}
+
+				e := NewEncoder()
+				e.AddDict(d)
+				compressed := e.AppendCompress(nil, src)
+
+				dec := NewDecoder()
+				dec.AddDict(d)
+				got, err := dec.AppendDecompress(nil, compressed)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, src) {
+					t.Fatal("mismatch")
+				}
+			})
+		}
+	})
+}
+
+func TestParseDict_Errors(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		if _, err := ParseDict(nil); err == nil {
+			t.Fatal("expected error for nil input")
+		}
+	})
+
+	t.Run("short", func(t *testing.T) {
+		if _, err := ParseDict(make([]byte, 10)); err == nil {
+			t.Fatal("expected error for short input")
+		}
+	})
+
+	t.Run("bad_magic", func(t *testing.T) {
+		bad := make([]byte, 100)
+		bad[0], bad[1], bad[2], bad[3] = 0x00, 0x00, 0x00, 0x00
+		if _, err := ParseDict(bad); !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("id0", func(t *testing.T) {
+		raw := append([]byte{}, loadTestDict(t)...)
+		binary.LittleEndian.PutUint32(raw[4:8], 0)
+		_, err := ParseDict(raw)
+		if err == nil || !strings.Contains(err.Error(), "dictionary ID 0") {
+			t.Fatalf("expected 'dictionary ID 0' error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid_offsets", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Locate offset position: after magic(4) + id(4) + huff table + 3 FSE tables.
+		// offsets are 12 bytes before content.
+		offsetPos := len(raw) - len(d.d.content) - 12
+
+		t.Run("zero", func(t *testing.T) {
+			b := append([]byte{}, raw...)
+			// Zero out all 3 offsets.
+			for i := range 12 {
+				b[offsetPos+i] = 0
+			}
+			_, err := ParseDict(b)
+			if err == nil || !strings.Contains(err.Error(), "invalid offset") {
+				t.Fatalf("expected 'invalid offset' error, got: %v", err)
+			}
+		})
+
+		t.Run("too_large", func(t *testing.T) {
+			b := append([]byte{}, raw...)
+			// Set first offset to huge value.
+			binary.LittleEndian.PutUint32(b[offsetPos:], uint32(len(d.d.content)+1000))
+			// Keep other offsets valid.
+			binary.LittleEndian.PutUint32(b[offsetPos+4:], 1)
+			binary.LittleEndian.PutUint32(b[offsetPos+8:], 1)
+			_, err := ParseDict(b)
+			if err == nil || !strings.Contains(err.Error(), "initial offset bigger") {
+				t.Fatalf("expected 'initial offset bigger' error, got: %v", err)
+			}
+		})
+	})
+
+	t.Run("truncated", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Cut right before the 12-byte offsets region.
+		offsetStart := len(raw) - len(d.d.content) - 12
+		truncPoints := []int{8, 12, 20, offsetStart - 1, offsetStart + 6}
+		for _, n := range truncPoints {
+			if n > len(raw) || n <= 0 {
+				continue
+			}
+			_, err := ParseDict(raw[:n])
+			if err == nil {
+				t.Fatalf("expected error for truncation at %d bytes", n)
+			}
+		}
+	})
+
+	t.Run("min_size", func(t *testing.T) {
+		// Exactly 8 (header) + 12 (offsets) = 20 bytes with valid magic + nonzero ID.
+		// No room for Huffman/FSE tables.
+		b := make([]byte, 20)
+		copy(b[:4], dictMagic)
+		binary.LittleEndian.PutUint32(b[4:8], 42)
+		_, err := ParseDict(b)
+		if err == nil {
+			t.Fatal("expected error for minimal-size dict with no tables")
+		}
+	})
+}
+
+func TestDict_NilSafety(t *testing.T) {
 	var d *Dict
 	if d.ID() != 0 {
 		t.Fatal("nil Dict.ID should be 0")
@@ -45,95 +228,707 @@ func TestDictNilSafety(t *testing.T) {
 	}
 }
 
-func TestRawDictRoundTripAllLevels(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("dictionary prefix content here! "), 100)
-	src := append([]byte{}, dictContent[500:1500]...)
-	src = append(src, []byte("and some unique new content")...)
-	src = bytes.Repeat(src, 10)
-
-	for level := BestSpeed; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			var buf bytes.Buffer
-			e := NewEncoder()
-			if err := e.SetLevel(level); err != nil {
-				t.Fatal(err)
-			}
-			e.SetRawDict(dictContent)
-			w := NewWriter(&buf, e)
-			w.Reset(&buf)
-			if _, err := w.Write(src); err != nil {
-				t.Fatal(err)
-			}
-			if err := w.Close(); err != nil {
-				t.Fatal(err)
-			}
-
-			dec := NewDecoder()
-			dec.SetRawDict(dictContent)
-			r := NewReader(bytes.NewReader(buf.Bytes()), dec)
-			got, err := io.ReadAll(r)
-			if err := r.Close(); err != nil {
-				t.Fatal(err)
-			}
-			if err != nil {
-				t.Fatalf("level %d: readall: %v", level, err)
-			}
-			if !bytes.Equal(got, src) {
-				t.Fatalf("level %d: mismatch: got %d, want %d bytes", level, len(got), len(src))
-			}
-		})
+func TestDict_MarshalBinary(t *testing.T) {
+	raw := loadTestDict(t)
+	d, err := ParseDict(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := d.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var d2 Dict
+	if err := d2.UnmarshalBinary(b); err != nil {
+		t.Fatal(err)
+	}
+	if d2.ID() != d.ID() {
+		t.Fatalf("ID: %d != %d", d2.ID(), d.ID())
+	}
+	if !bytes.Equal(d2.Bytes(), d.Bytes()) {
+		t.Fatal("Bytes mismatch")
 	}
 }
 
-func TestRawDictAppendTo(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("encode-all dict prefix "), 80)
-	src := append([]byte{}, dictContent[200:800]...)
-	src = append(src, bytes.Repeat([]byte("extra payload "), 50)...)
+func TestEncoder_SetRawDict(t *testing.T) {
+	t.Run("round_trip_all_levels", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("dictionary prefix content here! "), 100)
+		src := append([]byte{}, dictContent[500:1500]...)
+		src = append(src, []byte("and some unique new content")...)
+		src = bytes.Repeat(src, 10)
 
-	for level := BestSpeed; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			e := NewEncoder()
-			if err := e.SetLevel(level); err != nil {
-				t.Fatal(err)
-			}
-			e.SetRawDict(dictContent)
-			compressed := e.AppendCompress(nil, src)
+		for level := BestSpeed; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				var buf bytes.Buffer
+				e := NewEncoder()
+				if err := e.SetLevel(level); err != nil {
+					t.Fatal(err)
+				}
+				e.SetRawDict(dictContent)
+				w := NewWriter(&buf, e)
+				w.Reset(&buf)
+				if _, err := w.Write(src); err != nil {
+					t.Fatal(err)
+				}
+				if err := w.Close(); err != nil {
+					t.Fatal(err)
+				}
 
-			dec := NewDecoder()
-			dec.SetRawDict(dictContent)
-			r := NewReader(bytes.NewReader(compressed), dec)
-			got, err := io.ReadAll(r)
-			if err := r.Close(); err != nil {
-				t.Fatal(err)
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(got, src) {
-				t.Fatalf("level %d: mismatch", level)
-			}
-		})
-	}
+				dec := NewDecoder()
+				dec.SetRawDict(dictContent)
+				r := NewReader(bytes.NewReader(buf.Bytes()), dec)
+				got, err := io.ReadAll(r)
+				if err := r.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if err != nil {
+					t.Fatalf("level %d: readall: %v", level, err)
+				}
+				if !bytes.Equal(got, src) {
+					t.Fatalf("level %d: mismatch: got %d, want %d bytes", level, len(got), len(src))
+				}
+			})
+		}
+	})
+
+	t.Run("append_to", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("encode-all dict prefix "), 80)
+		src := append([]byte{}, dictContent[200:800]...)
+		src = append(src, bytes.Repeat([]byte("extra payload "), 50)...)
+
+		for level := BestSpeed; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				e := NewEncoder()
+				if err := e.SetLevel(level); err != nil {
+					t.Fatal(err)
+				}
+				e.SetRawDict(dictContent)
+				compressed := e.AppendCompress(nil, src)
+
+				dec := NewDecoder()
+				dec.SetRawDict(dictContent)
+				r := NewReader(bytes.NewReader(compressed), dec)
+				got, err := io.ReadAll(r)
+				if err := r.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, src) {
+					t.Fatalf("level %d: mismatch", level)
+				}
+			})
+		}
+	})
+
+	t.Run("improves_compression", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog "), 100)
+		// Data that heavily references dict content.
+		src := append([]byte{}, dictContent[:2000]...)
+		src = append(src, []byte("tiny unique suffix")...)
+
+		e := NewEncoder()
+
+		// Without dict.
+		noDictCompressed := e.AppendCompress(nil, src)
+
+		// With dict.
+		e.SetRawDict(dictContent)
+		withDictCompressed := e.AppendCompress(nil, src)
+
+		if len(withDictCompressed) > len(noDictCompressed) {
+			t.Fatalf("dict should help: with=%d, without=%d", len(withDictCompressed), len(noDictCompressed))
+		}
+	})
+
+	t.Run("content_match", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("AAABBBCCC"), 500)
+		src := append([]byte{}, dictContent[:2000]...)
+		src = append(src, []byte("unique tail")...)
+
+		e := NewEncoder()
+
+		noDictCompressed := e.AppendCompress(nil, src)
+
+		e.SetRawDict(dictContent)
+		withDictCompressed := e.AppendCompress(nil, src)
+
+		if len(withDictCompressed) >= len(noDictCompressed) {
+			t.Fatalf("dict should shrink output: with=%d, without=%d", len(withDictCompressed), len(noDictCompressed))
+		}
+	})
+
+	t.Run("small", func(t *testing.T) {
+		src := bytes.Repeat([]byte("small dict edge case "), 50)
+		for _, sz := range []int{8, 16} {
+			t.Run("", func(t *testing.T) {
+				dictContent := bytes.Repeat([]byte("x"), sz)
+				e := NewEncoder()
+				e.SetRawDict(dictContent)
+				compressed := e.AppendCompress(nil, src)
+
+				dec := NewDecoder()
+				dec.SetRawDict(dictContent)
+				r := NewReader(bytes.NewReader(compressed), dec)
+				got, err := io.ReadAll(r)
+				_ = r.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, src) {
+					t.Fatal("mismatch")
+				}
+			})
+		}
+	})
+
+	t.Run("too_short", func(t *testing.T) {
+		src := bytes.Repeat([]byte("short dict ignored "), 50)
+
+		// Compress without dict.
+		e := NewEncoder()
+		want := e.AppendCompress(nil, src)
+
+		// SetRawDict with < 8 bytes should be silently ignored.
+		for _, sz := range []int{1, 4, 7} {
+			t.Run("", func(t *testing.T) {
+				e2 := NewEncoder()
+				e2.SetRawDict(bytes.Repeat([]byte("x"), sz))
+				got := e2.AppendCompress(nil, src)
+				if !bytes.Equal(got, want) {
+					t.Fatalf("sz=%d: short dict was not ignored (output differs)", sz)
+				}
+			})
+		}
+
+		// Reader side: short dict should not register.
+		dec := NewDecoder()
+		dec.SetRawDict(bytes.Repeat([]byte("x"), 3))
+		got, err := dec.AppendDecompress(nil, want)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("reader mismatch")
+		}
+	})
+
+	t.Run("short_no_op", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("real dict "), 50)
+		src := bytes.Repeat([]byte("data "), 100)
+
+		// Compress with dict.
+		e := NewEncoder()
+		e.SetRawDict(dictContent)
+		withDict := e.AppendCompress(nil, src)
+
+		// Short dict should be a no-op — dict stays.
+		e.SetRawDict([]byte("x"))
+		stillWithDict := e.AppendCompress(nil, src)
+
+		if !bytes.Equal(withDict, stillWithDict) {
+			t.Fatal("short SetRawDict should not have cleared dict")
+		}
+	})
+
+	t.Run("nil_clear", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("dict content "), 50)
+		src := []byte("hello world, compressed without dict")
+
+		var buf bytes.Buffer
+		e := NewEncoder()
+		e.SetRawDict(dictContent)
+		e.SetRawDict(nil) // clear dict
+		w := NewWriter(&buf, e)
+		w.Reset(&buf)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		got, err := io.ReadAll(r)
+		_ = r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("nil_clear_via_adddict", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("dict content "), 50)
+		src := []byte("hello world, compressed without dict")
+
+		var buf bytes.Buffer
+		e := NewEncoder()
+		e.SetRawDict(dictContent)
+		e.AddDict(nil) // clear dict
+		w := NewWriter(&buf, e)
+		w.Reset(&buf)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		got, err := io.ReadAll(r)
+		_ = r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("reuse", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("encode-all dict prefix "), 80)
+		src1 := append([]byte{}, dictContent[200:800]...)
+		src1 = append(src1, bytes.Repeat([]byte("frame 1 payload "), 50)...)
+		src2 := append([]byte{}, dictContent[100:600]...)
+		src2 = append(src2, bytes.Repeat([]byte("frame 2 payload "), 50)...)
+
+		for _, frame := range []struct {
+			name string
+			src  []byte
+		}{{"frame1", src1}, {"frame2", src2}} {
+			t.Run(frame.name, func(t *testing.T) {
+				e := NewEncoder()
+				e.SetRawDict(dictContent)
+				compressed := e.AppendCompress(nil, frame.src)
+
+				dec := NewDecoder()
+				dec.SetRawDict(dictContent)
+				r := NewReader(bytes.NewReader(compressed), dec)
+				got, err := io.ReadAll(r)
+				_ = r.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, frame.src) {
+					t.Fatal("mismatch")
+				}
+			})
+		}
+	})
 }
 
-func TestRawDictImprovesCompression(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog "), 100)
-	// Data that heavily references dict content.
-	src := append([]byte{}, dictContent[:2000]...)
-	src = append(src, []byte("tiny unique suffix")...)
+func TestEncoder_AddDict(t *testing.T) {
+	t.Run("round_trip", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := bytes.Repeat([]byte("parsed dict roundtrip test data "), 200)
 
-	e := NewEncoder()
+		for level := BestSpeed; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				e := NewEncoder()
+				if err := e.SetLevel(level); err != nil {
+					t.Fatal(err)
+				}
+				e.AddDict(d)
+				compressed := e.AppendCompress(nil, src)
 
-	// Without dict.
-	noDictCompressed := e.AppendCompress(nil, src)
+				dec := NewDecoder()
+				dec.AddDict(d)
+				r := NewReader(bytes.NewReader(compressed), dec)
+				got, err := io.ReadAll(r)
+				if err := r.Close(); err != nil {
+					t.Fatal(err)
+				}
+				if err != nil {
+					t.Fatalf("level %d: %v", level, err)
+				}
+				if !bytes.Equal(got, src) {
+					t.Fatalf("level %d: mismatch: got %d, want %d bytes", level, len(got), len(src))
+				}
+			})
+		}
+	})
 
-	// With dict.
-	e.SetRawDict(dictContent)
-	withDictCompressed := e.AppendCompress(nil, src)
+	t.Run("stream_round_trip", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := bytes.Repeat([]byte("streaming parsed dict test "), 300)
 
-	if len(withDictCompressed) > len(noDictCompressed) {
-		t.Fatalf("dict should help: with=%d, without=%d", len(withDictCompressed), len(noDictCompressed))
-	}
+		var buf bytes.Buffer
+		e := NewEncoder()
+		e.AddDict(d)
+		w := NewWriter(&buf, e)
+		w.Reset(&buf)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		dec := NewDecoder()
+		dec.AddDict(d)
+		r := NewReader(bytes.NewReader(buf.Bytes()), dec)
+		got, err := io.ReadAll(r)
+		_ = r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatalf("mismatch: got %d, want %d bytes", len(got), len(src))
+		}
+	})
+
+	t.Run("multi_block", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// > 128KB to force multiple blocks.
+		src := bytes.Repeat([]byte("multiblock dict content xyz "), 6000)
+
+		e := NewEncoder()
+		e.AddDict(d)
+		compressed := e.AppendCompress(nil, src)
+
+		dec := NewDecoder()
+		dec.AddDict(d)
+		r := NewReader(bytes.NewReader(compressed), dec)
+		got, err := io.ReadAll(r)
+		_ = r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatalf("mismatch: got %d, want %d bytes", len(got), len(src))
+		}
+	})
+
+	t.Run("append_compress", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := bytes.Repeat([]byte("decode-all parsed dict test "), 100)
+
+		e := NewEncoder()
+		e.AddDict(d)
+		compressed := e.AppendCompress(nil, src)
+
+		dec := NewDecoder()
+		dec.AddDict(d)
+		got, err := dec.AppendDecompress(nil, compressed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatalf("mismatch: got %d, want %d bytes", len(got), len(src))
+		}
+	})
+}
+
+func TestDecoder_SetRawDict(t *testing.T) {
+	t.Run("nil_clear", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := bytes.Repeat([]byte("reader raw dict nil clear "), 50)
+
+		e := NewEncoder()
+		e.AddDict(d)
+		compressed := e.AppendCompress(nil, src)
+
+		dec := NewDecoder()
+		dec.AddDict(d)
+		r := NewReader(bytes.NewReader(compressed), dec)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch before clear")
+		}
+
+		dec.SetRawDict(nil) // clear all dicts
+		if err := r.Reset(bytes.NewReader(compressed)); err != nil {
+			t.Fatal(err)
+		}
+		_, err = io.ReadAll(r)
+		_ = r.Close()
+		if err != ErrUnknownDictionary {
+			t.Fatalf("expected ErrUnknownDictionary, got: %v", err)
+		}
+	})
+
+	t.Run("short_no_op", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("real dict content "), 50)
+		src := bytes.Repeat([]byte("data "), 100)
+
+		e := NewEncoder()
+		e.SetRawDict(dictContent)
+		compressed := e.AppendCompress(nil, src)
+
+		dec := NewDecoder()
+		dec.SetRawDict(dictContent)
+
+		// Short dict should be a no-op — real dict stays.
+		dec.SetRawDict([]byte("short"))
+
+		got, err := dec.AppendDecompress(nil, compressed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch — short dict should not have cleared previous")
+		}
+	})
+
+	t.Run("exactly_8", func(t *testing.T) {
+		dict := []byte("12345678")
+		src := bytes.Repeat([]byte("exactly8 "), 100)
+
+		e := NewEncoder()
+		e.SetRawDict(dict)
+		compressed := e.AppendCompress(nil, src)
+
+		dec := NewDecoder()
+		dec.SetRawDict(dict)
+		got, err := dec.AppendDecompress(nil, compressed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("reuse_across_reset", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("encode-all dict prefix "), 80)
+		src1 := append([]byte{}, dictContent[200:800]...)
+		src1 = append(src1, bytes.Repeat([]byte("reader frame 1 "), 50)...)
+		src2 := append([]byte{}, dictContent[100:600]...)
+		src2 = append(src2, bytes.Repeat([]byte("reader frame 2 "), 50)...)
+
+		// Compress each frame with its own writer to avoid writer reuse issues.
+		compress := func(src []byte) []byte {
+			e := NewEncoder()
+			e.SetRawDict(dictContent)
+			return e.AppendCompress(nil, src)
+		}
+		comp1 := compress(src1)
+		comp2 := compress(src2)
+
+		dec := NewDecoder()
+		dec.SetRawDict(dictContent)
+		r := NewReader(bytes.NewReader(comp1), dec)
+		got1, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got1, src1) {
+			t.Fatal("frame 1 mismatch")
+		}
+
+		if err := r.Reset(bytes.NewReader(comp2)); err != nil {
+			t.Fatal(err)
+		}
+		got2, err := io.ReadAll(r)
+		if err := r.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got2, src2) {
+			t.Fatal("frame 2 mismatch")
+		}
+	})
+
+	t.Run("switch_between_frames", func(t *testing.T) {
+		dict1 := bytes.Repeat([]byte("dict one content "), 50)
+		dict2 := bytes.Repeat([]byte("dict two content "), 50)
+		src := bytes.Repeat([]byte("payload "), 100)
+
+		e1 := NewEncoder()
+		e1.SetRawDict(dict1)
+		frame1 := e1.AppendCompress(nil, src)
+
+		e2 := NewEncoder()
+		e2.SetRawDict(dict2)
+		frame2 := e2.AppendCompress(nil, src)
+
+		// Reader switches dicts between frames.
+		dec := NewDecoder()
+		dec.SetRawDict(dict1)
+		r := NewReader(bytes.NewReader(frame1), dec)
+		got1, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got1, src) {
+			t.Fatal("frame 1 mismatch")
+		}
+
+		dec.SetRawDict(dict2)
+		if err := r.Reset(bytes.NewReader(frame2)); err != nil {
+			t.Fatal(err)
+		}
+		got2, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got2, src) {
+			t.Fatal("frame 2 mismatch")
+		}
+	})
+}
+
+func TestDecoder_AddDict(t *testing.T) {
+	t.Run("nil_clear", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		src := bytes.Repeat([]byte("reader add dict nil clear "), 50)
+
+		e := NewEncoder()
+		e.AddDict(d)
+		compressed := e.AppendCompress(nil, src)
+
+		dec := NewDecoder()
+		dec.AddDict(d)
+		r := NewReader(bytes.NewReader(compressed), dec)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch before clear")
+		}
+
+		dec.AddDict(nil)
+		if err := r.Reset(bytes.NewReader(compressed)); err != nil {
+			t.Fatal(err)
+		}
+		_, err = io.ReadAll(r)
+		_ = r.Close()
+		if err != ErrUnknownDictionary {
+			t.Fatalf("expected ErrUnknownDictionary, got: %v", err)
+		}
+	})
+
+	t.Run("multiple_registered", func(t *testing.T) {
+		raw := loadTestDict(t)
+
+		// Dict A: ID = 111.
+		rawA := append([]byte{}, raw...)
+		binary.LittleEndian.PutUint32(rawA[4:8], 111)
+		dA, err := ParseDict(rawA)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Dict B: ID = 222.
+		rawB := append([]byte{}, raw...)
+		binary.LittleEndian.PutUint32(rawB[4:8], 222)
+		dB, err := ParseDict(rawB)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		srcA := bytes.Repeat([]byte("frame A data "), 100)
+		srcB := bytes.Repeat([]byte("frame B data "), 100)
+
+		eA := NewEncoder()
+		eA.AddDict(dA)
+		compA := eA.AppendCompress(nil, srcA)
+
+		eB := NewEncoder()
+		eB.AddDict(dB)
+		compB := eB.AppendCompress(nil, srcB)
+
+		// Concatenate two frames.
+		combined := append(compA, compB...)
+
+		dec := NewDecoder()
+		dec.AddDict(dA)
+		dec.AddDict(dB)
+		got, err := dec.AppendDecompress(nil, combined)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := append(srcA, srcB...)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("mismatch: got %d, want %d bytes", len(got), len(want))
+		}
+	})
+
+	t.Run("nil_clear_multiple", func(t *testing.T) {
+		raw := loadTestDict(t)
+		d, err := ParseDict(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dictContent := bytes.Repeat([]byte("raw dict for multi clear "), 100)
+		src := bytes.Repeat([]byte("multi dict clear test "), 50)
+
+		// Compress with parsed dict.
+		eParsed := NewEncoder()
+		eParsed.AddDict(d)
+		compParsed := eParsed.AppendCompress(nil, src)
+
+		// Compress with raw dict.
+		eRaw := NewEncoder()
+		eRaw.SetRawDict(dictContent)
+		compRaw := eRaw.AppendCompress(nil, src)
+
+		dec := NewDecoder()
+		dec.AddDict(d)
+		dec.SetRawDict(dictContent)
+
+		// Both should decode.
+		got, err := dec.AppendDecompress(nil, compParsed)
+		if err != nil {
+			t.Fatalf("parsed dict decode: %v", err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("parsed dict mismatch")
+		}
+		got, err = dec.AppendDecompress(nil, compRaw)
+		if err != nil {
+			t.Fatalf("raw dict decode: %v", err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("raw dict mismatch")
+		}
+
+		dec.AddDict(nil) // clear all
+
+		_, err = dec.AppendDecompress(nil, compParsed)
+		if err != ErrUnknownDictionary {
+			t.Fatalf("parsed dict after clear: expected ErrUnknownDictionary, got: %v", err)
+		}
+		_, err = dec.AppendDecompress(nil, compRaw)
+		// Raw dict (ID 0) doesn't embed a dict ID in the frame, so the error
+		// is a corruption from bad offsets rather than ErrUnknownDictionary.
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("raw dict after clear: expected ErrCorrupted, got: %v", err)
+		}
+	})
 }
 
 func TestNoDictDecodeWithDict(t *testing.T) {
@@ -156,261 +951,6 @@ func TestNoDictDecodeWithDict(t *testing.T) {
 	}
 	if !bytes.Equal(got, src) {
 		t.Fatal("mismatch")
-	}
-}
-
-func TestDictNilClear(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("dict content "), 50)
-	src := []byte("hello world, compressed without dict")
-
-	var buf bytes.Buffer
-	e := NewEncoder()
-	e.SetRawDict(dictContent)
-	e.AddDict(nil) // clear dict
-	w := NewWriter(&buf, e)
-	w.Reset(&buf)
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	_ = r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func loadTestDict(t *testing.T) []byte {
-	t.Helper()
-	b, err := os.ReadFile("testdata/d0.dict")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return b
-}
-
-func TestParseDictFormat(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if d.ID() == 0 {
-		t.Fatal("expected non-zero dict ID")
-	}
-	if !bytes.Equal(d.Bytes(), raw) {
-		t.Fatal("Bytes() != input")
-	}
-	if d.d.litEnc == nil {
-		t.Fatal("litEnc is nil")
-	}
-	for i, off := range d.d.offsets {
-		if off <= 0 {
-			t.Fatalf("offset[%d] = %d, want > 0", i, off)
-		}
-	}
-	if len(d.d.content) == 0 {
-		t.Fatal("content is empty")
-	}
-}
-
-func TestParseDictID0Rejected(t *testing.T) {
-	raw := append([]byte{}, loadTestDict(t)...)
-	binary.LittleEndian.PutUint32(raw[4:8], 0)
-	_, err := ParseDict(raw)
-	if err == nil || !strings.Contains(err.Error(), "dictionary ID 0") {
-		t.Fatalf("expected 'dictionary ID 0' error, got: %v", err)
-	}
-}
-
-func TestParseDictInvalidOffsets(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Locate offset position: after magic(4) + id(4) + huff table + 3 FSE tables.
-	// offsets are 12 bytes before content.
-	offsetPos := len(raw) - len(d.d.content) - 12
-
-	t.Run("zero", func(t *testing.T) {
-		b := append([]byte{}, raw...)
-		// Zero out all 3 offsets.
-		for i := range 12 {
-			b[offsetPos+i] = 0
-		}
-		_, err := ParseDict(b)
-		if err == nil || !strings.Contains(err.Error(), "invalid offset") {
-			t.Fatalf("expected 'invalid offset' error, got: %v", err)
-		}
-	})
-
-	t.Run("too_large", func(t *testing.T) {
-		b := append([]byte{}, raw...)
-		// Set first offset to huge value.
-		binary.LittleEndian.PutUint32(b[offsetPos:], uint32(len(d.d.content)+1000))
-		// Keep other offsets valid.
-		binary.LittleEndian.PutUint32(b[offsetPos+4:], 1)
-		binary.LittleEndian.PutUint32(b[offsetPos+8:], 1)
-		_, err := ParseDict(b)
-		if err == nil || !strings.Contains(err.Error(), "initial offset bigger") {
-			t.Fatalf("expected 'initial offset bigger' error, got: %v", err)
-		}
-	})
-}
-
-func TestParseDictTruncated(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Cut right before the 12-byte offsets region.
-	offsetStart := len(raw) - len(d.d.content) - 12
-	truncPoints := []int{8, 12, 20, offsetStart - 1, offsetStart + 6}
-	for _, n := range truncPoints {
-		if n > len(raw) || n <= 0 {
-			continue
-		}
-		_, err := ParseDict(raw[:n])
-		if err == nil {
-			t.Fatalf("expected error for truncation at %d bytes", n)
-		}
-	}
-}
-
-func TestParseDictMinSize(t *testing.T) {
-	// Exactly 8 (header) + 12 (offsets) = 20 bytes with valid magic + nonzero ID.
-	// No room for Huffman/FSE tables.
-	b := make([]byte, 20)
-	copy(b[:4], dictMagic)
-	binary.LittleEndian.PutUint32(b[4:8], 42)
-	_, err := ParseDict(b)
-	if err == nil {
-		t.Fatal("expected error for minimal-size dict with no tables")
-	}
-}
-
-func TestParsedDictRoundTrip(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	src := bytes.Repeat([]byte("parsed dict roundtrip test data "), 200)
-
-	for level := BestSpeed; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			e := NewEncoder()
-			if err := e.SetLevel(level); err != nil {
-				t.Fatal(err)
-			}
-			e.AddDict(d)
-			compressed := e.AppendCompress(nil, src)
-
-			dec := NewDecoder()
-			dec.AddDict(d)
-			r := NewReader(bytes.NewReader(compressed), dec)
-			got, err := io.ReadAll(r)
-			if err := r.Close(); err != nil {
-				t.Fatal(err)
-			}
-			if err != nil {
-				t.Fatalf("level %d: %v", level, err)
-			}
-			if !bytes.Equal(got, src) {
-				t.Fatalf("level %d: mismatch: got %d, want %d bytes", level, len(got), len(src))
-			}
-		})
-	}
-}
-
-func TestParsedDictStreamRoundTrip(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	src := bytes.Repeat([]byte("streaming parsed dict test "), 300)
-
-	var buf bytes.Buffer
-	e := NewEncoder()
-	e.AddDict(d)
-	w := NewWriter(&buf, e)
-	w.Reset(&buf)
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	dec := NewDecoder()
-	dec.AddDict(d)
-	r := NewReader(bytes.NewReader(buf.Bytes()), dec)
-	got, err := io.ReadAll(r)
-	_ = r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatalf("mismatch: got %d, want %d bytes", len(got), len(src))
-	}
-}
-
-func TestParsedDictMultiBlock(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// > 128KB to force multiple blocks.
-	src := bytes.Repeat([]byte("multiblock dict content xyz "), 6000)
-
-	e := NewEncoder()
-	e.AddDict(d)
-	compressed := e.AppendCompress(nil, src)
-
-	dec := NewDecoder()
-	dec.AddDict(d)
-	r := NewReader(bytes.NewReader(compressed), dec)
-	got, err := io.ReadAll(r)
-	_ = r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatalf("mismatch: got %d, want %d bytes", len(got), len(src))
-	}
-}
-
-func TestParsedDictAppendCompress(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	src := bytes.Repeat([]byte("decode-all parsed dict test "), 100)
-
-	e := NewEncoder()
-	e.AddDict(d)
-	compressed := e.AppendCompress(nil, src)
-
-	dec := NewDecoder()
-	dec.AddDict(d)
-	got, err := dec.AppendDecompress(nil, compressed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatalf("mismatch: got %d, want %d bytes", len(got), len(src))
 	}
 }
 
@@ -439,530 +979,5 @@ func TestDictIDMismatch(t *testing.T) {
 	_, err = dec.AppendDecompress(nil, compressed)
 	if err != ErrUnknownDictionary {
 		t.Fatalf("DecodeBytes: expected ErrUnknownDictionary, got: %v", err)
-	}
-}
-
-func TestDictIDFrameEncoding(t *testing.T) {
-	raw := loadTestDict(t)
-	src := bytes.Repeat([]byte("dict id frame encoding "), 50)
-
-	// Test different ID ranges: 1-byte (<256), 2-byte (<65536), 4-byte (>=65536).
-	ids := []uint32{1, 200, 60000, 100000}
-	for _, id := range ids {
-		t.Run("", func(t *testing.T) {
-			b := append([]byte{}, raw...)
-			binary.LittleEndian.PutUint32(b[4:8], id)
-			d, err := ParseDict(b)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if d.ID() != id {
-				t.Fatalf("ID: got %d, want %d", d.ID(), id)
-			}
-
-			e := NewEncoder()
-			e.AddDict(d)
-			compressed := e.AppendCompress(nil, src)
-
-			dec := NewDecoder()
-			dec.AddDict(d)
-			got, err := dec.AppendDecompress(nil, compressed)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(got, src) {
-				t.Fatal("mismatch")
-			}
-		})
-	}
-}
-
-func TestMultipleDictsRegistered(t *testing.T) {
-	raw := loadTestDict(t)
-
-	// Dict A: ID = 111.
-	rawA := append([]byte{}, raw...)
-	binary.LittleEndian.PutUint32(rawA[4:8], 111)
-	dA, err := ParseDict(rawA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Dict B: ID = 222.
-	rawB := append([]byte{}, raw...)
-	binary.LittleEndian.PutUint32(rawB[4:8], 222)
-	dB, err := ParseDict(rawB)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	srcA := bytes.Repeat([]byte("frame A data "), 100)
-	srcB := bytes.Repeat([]byte("frame B data "), 100)
-
-	eA := NewEncoder()
-	eA.AddDict(dA)
-	compA := eA.AppendCompress(nil, srcA)
-
-	eB := NewEncoder()
-	eB.AddDict(dB)
-	compB := eB.AppendCompress(nil, srcB)
-
-	// Concatenate two frames.
-	combined := append(compA, compB...)
-
-	dec := NewDecoder()
-	dec.AddDict(dA)
-	dec.AddDict(dB)
-	got, err := dec.AppendDecompress(nil, combined)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := append(srcA, srcB...)
-	if !bytes.Equal(got, want) {
-		t.Fatalf("mismatch: got %d, want %d bytes", len(got), len(want))
-	}
-}
-
-func TestParsedDictOffsetsNotDefault(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for i, off := range d.d.offsets {
-		if off <= 0 {
-			t.Fatalf("offset[%d] = %d, want > 0", i, off)
-		}
-		if off > len(d.d.content) {
-			t.Fatalf("offset[%d] = %d, exceeds content length %d", i, off, len(d.d.content))
-		}
-	}
-}
-
-func TestRawDictContentMatchReferences(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("AAABBBCCC"), 500)
-	src := append([]byte{}, dictContent[:2000]...)
-	src = append(src, []byte("unique tail")...)
-
-	e := NewEncoder()
-
-	noDictCompressed := e.AppendCompress(nil, src)
-
-	e.SetRawDict(dictContent)
-	withDictCompressed := e.AppendCompress(nil, src)
-
-	if len(withDictCompressed) >= len(noDictCompressed) {
-		t.Fatalf("dict should shrink output: with=%d, without=%d", len(withDictCompressed), len(noDictCompressed))
-	}
-}
-
-func TestParsedDictContentSize(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(d.d.content) == 0 {
-		t.Fatal("content is empty")
-	}
-	if len(d.d.content) >= len(raw) {
-		t.Fatalf("content (%d) should be smaller than raw (%d)", len(d.d.content), len(raw))
-	}
-}
-
-func TestRawDictSmall(t *testing.T) {
-	src := bytes.Repeat([]byte("small dict edge case "), 50)
-	for _, sz := range []int{8, 16} {
-		t.Run("", func(t *testing.T) {
-			dictContent := bytes.Repeat([]byte("x"), sz)
-			e := NewEncoder()
-			e.SetRawDict(dictContent)
-			compressed := e.AppendCompress(nil, src)
-
-			dec := NewDecoder()
-			dec.SetRawDict(dictContent)
-			r := NewReader(bytes.NewReader(compressed), dec)
-			got, err := io.ReadAll(r)
-			_ = r.Close()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(got, src) {
-				t.Fatal("mismatch")
-			}
-		})
-	}
-}
-
-func TestRawDictTooShortIgnored(t *testing.T) {
-	src := bytes.Repeat([]byte("short dict ignored "), 50)
-
-	// Compress without dict.
-	e := NewEncoder()
-	want := e.AppendCompress(nil, src)
-
-	// SetRawDict with < 8 bytes should be silently ignored.
-	for _, sz := range []int{1, 4, 7} {
-		t.Run("", func(t *testing.T) {
-			e2 := NewEncoder()
-			e2.SetRawDict(bytes.Repeat([]byte("x"), sz))
-			got := e2.AppendCompress(nil, src)
-			if !bytes.Equal(got, want) {
-				t.Fatalf("sz=%d: short dict was not ignored (output differs)", sz)
-			}
-		})
-	}
-
-	// Reader side: short dict should not register.
-	dec := NewDecoder()
-	dec.SetRawDict(bytes.Repeat([]byte("x"), 3))
-	got, err := dec.AppendDecompress(nil, want)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("reader mismatch")
-	}
-}
-
-func TestDictWriterReuseAcrossReset(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("encode-all dict prefix "), 80)
-	src1 := append([]byte{}, dictContent[200:800]...)
-	src1 = append(src1, bytes.Repeat([]byte("frame 1 payload "), 50)...)
-	src2 := append([]byte{}, dictContent[100:600]...)
-	src2 = append(src2, bytes.Repeat([]byte("frame 2 payload "), 50)...)
-
-	for _, frame := range []struct {
-		name string
-		src  []byte
-	}{{"frame1", src1}, {"frame2", src2}} {
-		t.Run(frame.name, func(t *testing.T) {
-			e := NewEncoder()
-			e.SetRawDict(dictContent)
-			compressed := e.AppendCompress(nil, frame.src)
-
-			dec := NewDecoder()
-			dec.SetRawDict(dictContent)
-			r := NewReader(bytes.NewReader(compressed), dec)
-			got, err := io.ReadAll(r)
-			_ = r.Close()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(got, frame.src) {
-				t.Fatal("mismatch")
-			}
-		})
-	}
-}
-
-func TestReaderAddDictNilClear(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	src := bytes.Repeat([]byte("reader add dict nil clear "), 50)
-
-	e := NewEncoder()
-	e.AddDict(d)
-	compressed := e.AppendCompress(nil, src)
-
-	dec := NewDecoder()
-	dec.AddDict(d)
-	r := NewReader(bytes.NewReader(compressed), dec)
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch before clear")
-	}
-
-	dec.AddDict(nil)
-	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
-		t.Fatal(err)
-	}
-	_, err = io.ReadAll(r)
-	_ = r.Close()
-	if err != ErrUnknownDictionary {
-		t.Fatalf("expected ErrUnknownDictionary, got: %v", err)
-	}
-}
-
-func TestReaderSetRawDictNilClear(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	src := bytes.Repeat([]byte("reader raw dict nil clear "), 50)
-
-	e := NewEncoder()
-	e.AddDict(d)
-	compressed := e.AppendCompress(nil, src)
-
-	dec := NewDecoder()
-	dec.AddDict(d)
-	r := NewReader(bytes.NewReader(compressed), dec)
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch before clear")
-	}
-
-	dec.SetRawDict(nil) // clear all dicts
-	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
-		t.Fatal(err)
-	}
-	_, err = io.ReadAll(r)
-	_ = r.Close()
-	if err != ErrUnknownDictionary {
-		t.Fatalf("expected ErrUnknownDictionary, got: %v", err)
-	}
-}
-
-func TestReaderNilClearMultipleDicts(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dictContent := bytes.Repeat([]byte("raw dict for multi clear "), 100)
-	src := bytes.Repeat([]byte("multi dict clear test "), 50)
-
-	// Compress with parsed dict.
-	eParsed := NewEncoder()
-	eParsed.AddDict(d)
-	compParsed := eParsed.AppendCompress(nil, src)
-
-	// Compress with raw dict.
-	eRaw := NewEncoder()
-	eRaw.SetRawDict(dictContent)
-	compRaw := eRaw.AppendCompress(nil, src)
-
-	dec := NewDecoder()
-	dec.AddDict(d)
-	dec.SetRawDict(dictContent)
-
-	// Both should decode.
-	got, err := dec.AppendDecompress(nil, compParsed)
-	if err != nil {
-		t.Fatalf("parsed dict decode: %v", err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("parsed dict mismatch")
-	}
-	got, err = dec.AppendDecompress(nil, compRaw)
-	if err != nil {
-		t.Fatalf("raw dict decode: %v", err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("raw dict mismatch")
-	}
-
-	dec.AddDict(nil) // clear all
-
-	_, err = dec.AppendDecompress(nil, compParsed)
-	if err != ErrUnknownDictionary {
-		t.Fatalf("parsed dict after clear: expected ErrUnknownDictionary, got: %v", err)
-	}
-	_, err = dec.AppendDecompress(nil, compRaw)
-	// Raw dict (ID 0) doesn't embed a dict ID in the frame, so the error
-	// is a corruption from bad offsets rather than ErrUnknownDictionary.
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("raw dict after clear: expected ErrCorrupted, got: %v", err)
-	}
-}
-
-func TestWriterSetRawDictNilClear(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("dict content "), 50)
-	src := []byte("hello world, compressed without dict")
-
-	var buf bytes.Buffer
-	e := NewEncoder()
-	e.SetRawDict(dictContent)
-	e.SetRawDict(nil) // clear dict
-	w := NewWriter(&buf, e)
-	w.Reset(&buf)
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	_ = r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestDictReaderReuseAcrossReset(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("encode-all dict prefix "), 80)
-	src1 := append([]byte{}, dictContent[200:800]...)
-	src1 = append(src1, bytes.Repeat([]byte("reader frame 1 "), 50)...)
-	src2 := append([]byte{}, dictContent[100:600]...)
-	src2 = append(src2, bytes.Repeat([]byte("reader frame 2 "), 50)...)
-
-	// Compress each frame with its own writer to avoid writer reuse issues.
-	compress := func(src []byte) []byte {
-		e := NewEncoder()
-		e.SetRawDict(dictContent)
-		return e.AppendCompress(nil, src)
-	}
-	comp1 := compress(src1)
-	comp2 := compress(src2)
-
-	dec := NewDecoder()
-	dec.SetRawDict(dictContent)
-	r := NewReader(bytes.NewReader(comp1), dec)
-	got1, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got1, src1) {
-		t.Fatal("frame 1 mismatch")
-	}
-
-	if err := r.Reset(bytes.NewReader(comp2)); err != nil {
-		t.Fatal(err)
-	}
-	got2, err := io.ReadAll(r)
-	if err := r.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got2, src2) {
-		t.Fatal("frame 2 mismatch")
-	}
-}
-
-func TestDictMarshalBinaryRoundTrip(t *testing.T) {
-	raw := loadTestDict(t)
-	d, err := ParseDict(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	b, err := d.MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-	var d2 Dict
-	if err := d2.UnmarshalBinary(b); err != nil {
-		t.Fatal(err)
-	}
-	if d2.ID() != d.ID() {
-		t.Fatalf("ID: %d != %d", d2.ID(), d.ID())
-	}
-	if !bytes.Equal(d2.Bytes(), d.Bytes()) {
-		t.Fatal("Bytes mismatch")
-	}
-}
-
-func TestReaderSetRawDictShortIsNoOp(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("real dict content "), 50)
-	src := bytes.Repeat([]byte("data "), 100)
-
-	e := NewEncoder()
-	e.SetRawDict(dictContent)
-	compressed := e.AppendCompress(nil, src)
-
-	dec := NewDecoder()
-	dec.SetRawDict(dictContent)
-
-	// Short dict should be a no-op — real dict stays.
-	dec.SetRawDict([]byte("short"))
-
-	got, err := dec.AppendDecompress(nil, compressed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch — short dict should not have cleared previous")
-	}
-}
-
-func TestReaderSetRawDictExactly8(t *testing.T) {
-	dict := []byte("12345678")
-	src := bytes.Repeat([]byte("exactly8 "), 100)
-
-	e := NewEncoder()
-	e.SetRawDict(dict)
-	compressed := e.AppendCompress(nil, src)
-
-	dec := NewDecoder()
-	dec.SetRawDict(dict)
-	got, err := dec.AppendDecompress(nil, compressed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestWriterSetRawDictShortIsNoOp(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("real dict "), 50)
-	src := bytes.Repeat([]byte("data "), 100)
-
-	// Compress with dict.
-	e := NewEncoder()
-	e.SetRawDict(dictContent)
-	withDict := e.AppendCompress(nil, src)
-
-	// Short dict should be a no-op — dict stays.
-	e.SetRawDict([]byte("x"))
-	stillWithDict := e.AppendCompress(nil, src)
-
-	if !bytes.Equal(withDict, stillWithDict) {
-		t.Fatal("short SetRawDict should not have cleared dict")
-	}
-}
-
-func TestDictSwitchBetweenFrames(t *testing.T) {
-	dict1 := bytes.Repeat([]byte("dict one content "), 50)
-	dict2 := bytes.Repeat([]byte("dict two content "), 50)
-	src := bytes.Repeat([]byte("payload "), 100)
-
-	e1 := NewEncoder()
-	e1.SetRawDict(dict1)
-	frame1 := e1.AppendCompress(nil, src)
-
-	e2 := NewEncoder()
-	e2.SetRawDict(dict2)
-	frame2 := e2.AppendCompress(nil, src)
-
-	// Reader switches dicts between frames.
-	dec := NewDecoder()
-	dec.SetRawDict(dict1)
-	r := NewReader(bytes.NewReader(frame1), dec)
-	got1, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got1, src) {
-		t.Fatal("frame 1 mismatch")
-	}
-
-	dec.SetRawDict(dict2)
-	if err := r.Reset(bytes.NewReader(frame2)); err != nil {
-		t.Fatal(err)
-	}
-	got2, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got2, src) {
-		t.Fatal("frame 2 mismatch")
 	}
 }

--- a/dict_test.go
+++ b/dict_test.go
@@ -54,11 +54,12 @@ func TestRawDictRoundTripAllLevels(t *testing.T) {
 	for level := BestSpeed; level <= BestCompression; level++ {
 		t.Run("", func(t *testing.T) {
 			var buf bytes.Buffer
-			w := NewWriter(&buf)
-			if err := w.SetLevel(level); err != nil {
+			e := NewEncoder()
+			if err := e.SetLevel(level); err != nil {
 				t.Fatal(err)
 			}
-			w.SetRawDict(dictContent)
+			e.SetRawDict(dictContent)
+			w := NewWriter(&buf, e)
 			w.Reset(&buf)
 			if _, err := w.Write(src); err != nil {
 				t.Fatal(err)
@@ -67,8 +68,9 @@ func TestRawDictRoundTripAllLevels(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			r := NewReader(bytes.NewReader(buf.Bytes()))
-			r.SetRawDict(dictContent)
+			dec := NewDecoder()
+			dec.SetRawDict(dictContent)
+			r := NewReader(bytes.NewReader(buf.Bytes()), dec)
 			got, err := io.ReadAll(r)
 			if err := r.Close(); err != nil {
 				t.Fatal(err)
@@ -90,15 +92,16 @@ func TestRawDictAppendTo(t *testing.T) {
 
 	for level := BestSpeed; level <= BestCompression; level++ {
 		t.Run("", func(t *testing.T) {
-			w := NewWriter(nil)
-			if err := w.SetLevel(level); err != nil {
+			e := NewEncoder()
+			if err := e.SetLevel(level); err != nil {
 				t.Fatal(err)
 			}
-			w.SetRawDict(dictContent)
-			compressed := w.AppendCompress(nil, src)
+			e.SetRawDict(dictContent)
+			compressed := e.AppendCompress(nil, src)
 
-			r := NewReader(bytes.NewReader(compressed))
-			r.SetRawDict(dictContent)
+			dec := NewDecoder()
+			dec.SetRawDict(dictContent)
+			r := NewReader(bytes.NewReader(compressed), dec)
 			got, err := io.ReadAll(r)
 			if err := r.Close(); err != nil {
 				t.Fatal(err)
@@ -119,14 +122,14 @@ func TestRawDictImprovesCompression(t *testing.T) {
 	src := append([]byte{}, dictContent[:2000]...)
 	src = append(src, []byte("tiny unique suffix")...)
 
-	w := NewWriter(nil)
+	e := NewEncoder()
 
 	// Without dict.
-	noDictCompressed := w.AppendCompress(nil, src)
+	noDictCompressed := e.AppendCompress(nil, src)
 
 	// With dict.
-	w.SetRawDict(dictContent)
-	withDictCompressed := w.AppendCompress(nil, src)
+	e.SetRawDict(dictContent)
+	withDictCompressed := e.AppendCompress(nil, src)
 
 	if len(withDictCompressed) > len(noDictCompressed) {
 		t.Fatalf("dict should help: with=%d, without=%d", len(withDictCompressed), len(noDictCompressed))
@@ -138,11 +141,12 @@ func TestNoDictDecodeWithDict(t *testing.T) {
 	src := bytes.Repeat([]byte("no dict needed "), 200)
 	dictContent := []byte("some dict content that is not used")
 
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
-	r.SetRawDict(dictContent)
+	dec := NewDecoder()
+	dec.SetRawDict(dictContent)
+	r := NewReader(bytes.NewReader(compressed), dec)
 	got, err := io.ReadAll(r)
 	if err := r.Close(); err != nil {
 		t.Fatal(err)
@@ -160,9 +164,10 @@ func TestDictNilClear(t *testing.T) {
 	src := []byte("hello world, compressed without dict")
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
-	w.SetRawDict(dictContent)
-	w.AddDict(nil) // clear dict
+	e := NewEncoder()
+	e.SetRawDict(dictContent)
+	e.AddDict(nil) // clear dict
+	w := NewWriter(&buf, e)
 	w.Reset(&buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
@@ -171,7 +176,7 @@ func TestDictNilClear(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -303,15 +308,16 @@ func TestParsedDictRoundTrip(t *testing.T) {
 
 	for level := BestSpeed; level <= BestCompression; level++ {
 		t.Run("", func(t *testing.T) {
-			w := NewWriter(nil)
-			if err := w.SetLevel(level); err != nil {
+			e := NewEncoder()
+			if err := e.SetLevel(level); err != nil {
 				t.Fatal(err)
 			}
-			w.AddDict(d)
-			compressed := w.AppendCompress(nil, src)
+			e.AddDict(d)
+			compressed := e.AppendCompress(nil, src)
 
-			r := NewReader(bytes.NewReader(compressed))
-			r.AddDict(d)
+			dec := NewDecoder()
+			dec.AddDict(d)
+			r := NewReader(bytes.NewReader(compressed), dec)
 			got, err := io.ReadAll(r)
 			if err := r.Close(); err != nil {
 				t.Fatal(err)
@@ -335,8 +341,9 @@ func TestParsedDictStreamRoundTrip(t *testing.T) {
 	src := bytes.Repeat([]byte("streaming parsed dict test "), 300)
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
-	w.AddDict(d)
+	e := NewEncoder()
+	e.AddDict(d)
+	w := NewWriter(&buf, e)
 	w.Reset(&buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
@@ -345,8 +352,9 @@ func TestParsedDictStreamRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
-	r.AddDict(d)
+	dec := NewDecoder()
+	dec.AddDict(d)
+	r := NewReader(bytes.NewReader(buf.Bytes()), dec)
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -366,12 +374,13 @@ func TestParsedDictMultiBlock(t *testing.T) {
 	// > 128KB to force multiple blocks.
 	src := bytes.Repeat([]byte("multiblock dict content xyz "), 6000)
 
-	w := NewWriter(nil)
-	w.AddDict(d)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	e.AddDict(d)
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
-	r.AddDict(d)
+	dec := NewDecoder()
+	dec.AddDict(d)
+	r := NewReader(bytes.NewReader(compressed), dec)
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -390,14 +399,13 @@ func TestParsedDictAppendCompress(t *testing.T) {
 	}
 	src := bytes.Repeat([]byte("decode-all parsed dict test "), 100)
 
-	w := NewWriter(nil)
-	w.AddDict(d)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	e.AddDict(d)
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(nil)
-	r.AddDict(d)
-	got, err := r.AppendDecompress(nil, compressed)
-	_ = r.Close()
+	dec := NewDecoder()
+	dec.AddDict(d)
+	got, err := dec.AppendDecompress(nil, compressed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -414,12 +422,12 @@ func TestDictIDMismatch(t *testing.T) {
 	}
 	src := bytes.Repeat([]byte("dict id mismatch test "), 50)
 
-	w := NewWriter(nil)
-	w.AddDict(d)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	e.AddDict(d)
+	compressed := e.AppendCompress(nil, src)
 
 	// Decode without dict registered → ErrUnknownDictionary.
-	r := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed), nil)
 	_, err = io.ReadAll(r)
 	_ = r.Close()
 	if err != ErrUnknownDictionary {
@@ -427,9 +435,8 @@ func TestDictIDMismatch(t *testing.T) {
 	}
 
 	// Also test DecodeBytes path.
-	r2 := NewReader(bytes.NewReader(nil))
-	_, err = r2.AppendDecompress(nil, compressed)
-	_ = r2.Close()
+	dec := NewDecoder()
+	_, err = dec.AppendDecompress(nil, compressed)
 	if err != ErrUnknownDictionary {
 		t.Fatalf("DecodeBytes: expected ErrUnknownDictionary, got: %v", err)
 	}
@@ -453,14 +460,13 @@ func TestDictIDFrameEncoding(t *testing.T) {
 				t.Fatalf("ID: got %d, want %d", d.ID(), id)
 			}
 
-			w := NewWriter(nil)
-			w.AddDict(d)
-			compressed := w.AppendCompress(nil, src)
+			e := NewEncoder()
+			e.AddDict(d)
+			compressed := e.AppendCompress(nil, src)
 
-			r := NewReader(bytes.NewReader(nil))
-			r.AddDict(d)
-			got, err := r.AppendDecompress(nil, compressed)
-			_ = r.Close()
+			dec := NewDecoder()
+			dec.AddDict(d)
+			got, err := dec.AppendDecompress(nil, compressed)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -492,22 +498,21 @@ func TestMultipleDictsRegistered(t *testing.T) {
 	srcA := bytes.Repeat([]byte("frame A data "), 100)
 	srcB := bytes.Repeat([]byte("frame B data "), 100)
 
-	wA := NewWriter(nil)
-	wA.AddDict(dA)
-	compA := wA.AppendCompress(nil, srcA)
+	eA := NewEncoder()
+	eA.AddDict(dA)
+	compA := eA.AppendCompress(nil, srcA)
 
-	wB := NewWriter(nil)
-	wB.AddDict(dB)
-	compB := wB.AppendCompress(nil, srcB)
+	eB := NewEncoder()
+	eB.AddDict(dB)
+	compB := eB.AppendCompress(nil, srcB)
 
 	// Concatenate two frames.
 	combined := append(compA, compB...)
 
-	r := NewReader(bytes.NewReader(nil))
-	r.AddDict(dA)
-	r.AddDict(dB)
-	got, err := r.AppendDecompress(nil, combined)
-	_ = r.Close()
+	dec := NewDecoder()
+	dec.AddDict(dA)
+	dec.AddDict(dB)
+	got, err := dec.AppendDecompress(nil, combined)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -538,12 +543,12 @@ func TestRawDictContentMatchReferences(t *testing.T) {
 	src := append([]byte{}, dictContent[:2000]...)
 	src = append(src, []byte("unique tail")...)
 
-	w := NewWriter(nil)
+	e := NewEncoder()
 
-	noDictCompressed := w.AppendCompress(nil, src)
+	noDictCompressed := e.AppendCompress(nil, src)
 
-	w.SetRawDict(dictContent)
-	withDictCompressed := w.AppendCompress(nil, src)
+	e.SetRawDict(dictContent)
+	withDictCompressed := e.AppendCompress(nil, src)
 
 	if len(withDictCompressed) >= len(noDictCompressed) {
 		t.Fatalf("dict should shrink output: with=%d, without=%d", len(withDictCompressed), len(noDictCompressed))
@@ -569,12 +574,13 @@ func TestRawDictSmall(t *testing.T) {
 	for _, sz := range []int{8, 16} {
 		t.Run("", func(t *testing.T) {
 			dictContent := bytes.Repeat([]byte("x"), sz)
-			w := NewWriter(nil)
-			w.SetRawDict(dictContent)
-			compressed := w.AppendCompress(nil, src)
+			e := NewEncoder()
+			e.SetRawDict(dictContent)
+			compressed := e.AppendCompress(nil, src)
 
-			r := NewReader(bytes.NewReader(compressed))
-			r.SetRawDict(dictContent)
+			dec := NewDecoder()
+			dec.SetRawDict(dictContent)
+			r := NewReader(bytes.NewReader(compressed), dec)
 			got, err := io.ReadAll(r)
 			_ = r.Close()
 			if err != nil {
@@ -591,15 +597,15 @@ func TestRawDictTooShortIgnored(t *testing.T) {
 	src := bytes.Repeat([]byte("short dict ignored "), 50)
 
 	// Compress without dict.
-	w := NewWriter(nil)
-	want := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	want := e.AppendCompress(nil, src)
 
 	// SetRawDict with < 8 bytes should be silently ignored.
 	for _, sz := range []int{1, 4, 7} {
 		t.Run("", func(t *testing.T) {
-			w2 := NewWriter(nil)
-			w2.SetRawDict(bytes.Repeat([]byte("x"), sz))
-			got := w2.AppendCompress(nil, src)
+			e2 := NewEncoder()
+			e2.SetRawDict(bytes.Repeat([]byte("x"), sz))
+			got := e2.AppendCompress(nil, src)
 			if !bytes.Equal(got, want) {
 				t.Fatalf("sz=%d: short dict was not ignored (output differs)", sz)
 			}
@@ -607,10 +613,9 @@ func TestRawDictTooShortIgnored(t *testing.T) {
 	}
 
 	// Reader side: short dict should not register.
-	r := NewReader(nil)
-	r.SetRawDict(bytes.Repeat([]byte("x"), 3))
-	got, err := r.AppendDecompress(nil, want)
-	_ = r.Close()
+	dec := NewDecoder()
+	dec.SetRawDict(bytes.Repeat([]byte("x"), 3))
+	got, err := dec.AppendDecompress(nil, want)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -631,12 +636,13 @@ func TestDictWriterReuseAcrossReset(t *testing.T) {
 		src  []byte
 	}{{"frame1", src1}, {"frame2", src2}} {
 		t.Run(frame.name, func(t *testing.T) {
-			w := NewWriter(nil)
-			w.SetRawDict(dictContent)
-			compressed := w.AppendCompress(nil, frame.src)
+			e := NewEncoder()
+			e.SetRawDict(dictContent)
+			compressed := e.AppendCompress(nil, frame.src)
 
-			r := NewReader(bytes.NewReader(compressed))
-			r.SetRawDict(dictContent)
+			dec := NewDecoder()
+			dec.SetRawDict(dictContent)
+			r := NewReader(bytes.NewReader(compressed), dec)
 			got, err := io.ReadAll(r)
 			_ = r.Close()
 			if err != nil {
@@ -657,12 +663,13 @@ func TestReaderAddDictNilClear(t *testing.T) {
 	}
 	src := bytes.Repeat([]byte("reader add dict nil clear "), 50)
 
-	w := NewWriter(nil)
-	w.AddDict(d)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	e.AddDict(d)
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
-	r.AddDict(d)
+	dec := NewDecoder()
+	dec.AddDict(d)
+	r := NewReader(bytes.NewReader(compressed), dec)
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -671,7 +678,7 @@ func TestReaderAddDictNilClear(t *testing.T) {
 		t.Fatal("mismatch before clear")
 	}
 
-	r.AddDict(nil)
+	dec.AddDict(nil)
 	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
 		t.Fatal(err)
 	}
@@ -690,12 +697,13 @@ func TestReaderSetRawDictNilClear(t *testing.T) {
 	}
 	src := bytes.Repeat([]byte("reader raw dict nil clear "), 50)
 
-	w := NewWriter(nil)
-	w.AddDict(d)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	e.AddDict(d)
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
-	r.AddDict(d)
+	dec := NewDecoder()
+	dec.AddDict(d)
+	r := NewReader(bytes.NewReader(compressed), dec)
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -704,7 +712,7 @@ func TestReaderSetRawDictNilClear(t *testing.T) {
 		t.Fatal("mismatch before clear")
 	}
 
-	r.SetRawDict(nil) // clear all dicts
+	dec.SetRawDict(nil) // clear all dicts
 	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
 		t.Fatal(err)
 	}
@@ -725,28 +733,28 @@ func TestReaderNilClearMultipleDicts(t *testing.T) {
 	src := bytes.Repeat([]byte("multi dict clear test "), 50)
 
 	// Compress with parsed dict.
-	wParsed := NewWriter(nil)
-	wParsed.AddDict(d)
-	compParsed := wParsed.AppendCompress(nil, src)
+	eParsed := NewEncoder()
+	eParsed.AddDict(d)
+	compParsed := eParsed.AppendCompress(nil, src)
 
 	// Compress with raw dict.
-	wRaw := NewWriter(nil)
-	wRaw.SetRawDict(dictContent)
-	compRaw := wRaw.AppendCompress(nil, src)
+	eRaw := NewEncoder()
+	eRaw.SetRawDict(dictContent)
+	compRaw := eRaw.AppendCompress(nil, src)
 
-	r := NewReader(nil)
-	r.AddDict(d)
-	r.SetRawDict(dictContent)
+	dec := NewDecoder()
+	dec.AddDict(d)
+	dec.SetRawDict(dictContent)
 
 	// Both should decode.
-	got, err := r.AppendDecompress(nil, compParsed)
+	got, err := dec.AppendDecompress(nil, compParsed)
 	if err != nil {
 		t.Fatalf("parsed dict decode: %v", err)
 	}
 	if !bytes.Equal(got, src) {
 		t.Fatal("parsed dict mismatch")
 	}
-	got, err = r.AppendDecompress(nil, compRaw)
+	got, err = dec.AppendDecompress(nil, compRaw)
 	if err != nil {
 		t.Fatalf("raw dict decode: %v", err)
 	}
@@ -754,14 +762,13 @@ func TestReaderNilClearMultipleDicts(t *testing.T) {
 		t.Fatal("raw dict mismatch")
 	}
 
-	r.AddDict(nil) // clear all
+	dec.AddDict(nil) // clear all
 
-	_, err = r.AppendDecompress(nil, compParsed)
+	_, err = dec.AppendDecompress(nil, compParsed)
 	if err != ErrUnknownDictionary {
 		t.Fatalf("parsed dict after clear: expected ErrUnknownDictionary, got: %v", err)
 	}
-	_, err = r.AppendDecompress(nil, compRaw)
-	_ = r.Close()
+	_, err = dec.AppendDecompress(nil, compRaw)
 	// Raw dict (ID 0) doesn't embed a dict ID in the frame, so the error
 	// is a corruption from bad offsets rather than ErrUnknownDictionary.
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -774,9 +781,10 @@ func TestWriterSetRawDictNilClear(t *testing.T) {
 	src := []byte("hello world, compressed without dict")
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
-	w.SetRawDict(dictContent)
-	w.SetRawDict(nil) // clear dict
+	e := NewEncoder()
+	e.SetRawDict(dictContent)
+	e.SetRawDict(nil) // clear dict
+	w := NewWriter(&buf, e)
 	w.Reset(&buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
@@ -785,7 +793,7 @@ func TestWriterSetRawDictNilClear(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -805,15 +813,16 @@ func TestDictReaderReuseAcrossReset(t *testing.T) {
 
 	// Compress each frame with its own writer to avoid writer reuse issues.
 	compress := func(src []byte) []byte {
-		w := NewWriter(nil)
-		w.SetRawDict(dictContent)
-		return w.AppendCompress(nil, src)
+		e := NewEncoder()
+		e.SetRawDict(dictContent)
+		return e.AppendCompress(nil, src)
 	}
 	comp1 := compress(src1)
 	comp2 := compress(src2)
 
-	r := NewReader(bytes.NewReader(comp1))
-	r.SetRawDict(dictContent)
+	dec := NewDecoder()
+	dec.SetRawDict(dictContent)
+	r := NewReader(bytes.NewReader(comp1), dec)
 	got1, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -863,18 +872,17 @@ func TestReaderSetRawDictShortIsNoOp(t *testing.T) {
 	dictContent := bytes.Repeat([]byte("real dict content "), 50)
 	src := bytes.Repeat([]byte("data "), 100)
 
-	w := NewWriter(nil)
-	w.SetRawDict(dictContent)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	e.SetRawDict(dictContent)
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(nil)
-	r.SetRawDict(dictContent)
+	dec := NewDecoder()
+	dec.SetRawDict(dictContent)
 
 	// Short dict should be a no-op — real dict stays.
-	r.SetRawDict([]byte("short"))
+	dec.SetRawDict([]byte("short"))
 
-	got, err := r.AppendDecompress(nil, compressed)
-	r.Close()
+	got, err := dec.AppendDecompress(nil, compressed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -887,14 +895,13 @@ func TestReaderSetRawDictExactly8(t *testing.T) {
 	dict := []byte("12345678")
 	src := bytes.Repeat([]byte("exactly8 "), 100)
 
-	w := NewWriter(nil)
-	w.SetRawDict(dict)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	e.SetRawDict(dict)
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(nil)
-	r.SetRawDict(dict)
-	got, err := r.AppendDecompress(nil, compressed)
-	r.Close()
+	dec := NewDecoder()
+	dec.SetRawDict(dict)
+	got, err := dec.AppendDecompress(nil, compressed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -908,13 +915,13 @@ func TestWriterSetRawDictShortIsNoOp(t *testing.T) {
 	src := bytes.Repeat([]byte("data "), 100)
 
 	// Compress with dict.
-	w := NewWriter(nil)
-	w.SetRawDict(dictContent)
-	withDict := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	e.SetRawDict(dictContent)
+	withDict := e.AppendCompress(nil, src)
 
 	// Short dict should be a no-op — dict stays.
-	w.SetRawDict([]byte("x"))
-	stillWithDict := w.AppendCompress(nil, src)
+	e.SetRawDict([]byte("x"))
+	stillWithDict := e.AppendCompress(nil, src)
 
 	if !bytes.Equal(withDict, stillWithDict) {
 		t.Fatal("short SetRawDict should not have cleared dict")
@@ -926,17 +933,18 @@ func TestDictSwitchBetweenFrames(t *testing.T) {
 	dict2 := bytes.Repeat([]byte("dict two content "), 50)
 	src := bytes.Repeat([]byte("payload "), 100)
 
-	w1 := NewWriter(nil)
-	w1.SetRawDict(dict1)
-	frame1 := w1.AppendCompress(nil, src)
+	e1 := NewEncoder()
+	e1.SetRawDict(dict1)
+	frame1 := e1.AppendCompress(nil, src)
 
-	w2 := NewWriter(nil)
-	w2.SetRawDict(dict2)
-	frame2 := w2.AppendCompress(nil, src)
+	e2 := NewEncoder()
+	e2.SetRawDict(dict2)
+	frame2 := e2.AppendCompress(nil, src)
 
 	// Reader switches dicts between frames.
-	r := NewReader(bytes.NewReader(frame1))
-	r.SetRawDict(dict1)
+	dec := NewDecoder()
+	dec.SetRawDict(dict1)
+	r := NewReader(bytes.NewReader(frame1), dec)
 	got1, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -945,7 +953,7 @@ func TestDictSwitchBetweenFrames(t *testing.T) {
 		t.Fatal("frame 1 mismatch")
 	}
 
-	r.SetRawDict(dict2)
+	dec.SetRawDict(dict2)
 	if err := r.Reset(bytes.NewReader(frame2)); err != nil {
 		t.Fatal(err)
 	}

--- a/dict_test.go
+++ b/dict_test.go
@@ -259,7 +259,6 @@ func TestWithEncoderRawDict(t *testing.T) {
 			t.Run("", func(t *testing.T) {
 				var buf bytes.Buffer
 				w := mustWriter(t, &buf, WithEncoderLevel(level), WithEncoderRawDict(dictContent))
-				w.Reset(&buf)
 				if _, err := w.Write(src); err != nil {
 					t.Fatal(err)
 				}
@@ -408,7 +407,6 @@ func TestWithEncoderRawDict(t *testing.T) {
 
 		var buf bytes.Buffer
 		w := mustWriter(t, &buf, WithEncoderRawDict(dictContent), WithEncoderRawDict(nil)) // second option clears dict
-		w.Reset(&buf)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
 		}
@@ -433,7 +431,6 @@ func TestWithEncoderRawDict(t *testing.T) {
 
 		var buf bytes.Buffer
 		w := mustWriter(t, &buf, WithEncoderRawDict(dictContent), WithEncoderDict(nil)) // second option clears dict
-		w.Reset(&buf)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
 		}
@@ -520,7 +517,6 @@ func TestWithEncoderDict(t *testing.T) {
 
 		var buf bytes.Buffer
 		w := mustWriter(t, &buf, WithEncoderDict(d))
-		w.Reset(&buf)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
 		}

--- a/dict_test.go
+++ b/dict_test.go
@@ -97,12 +97,10 @@ func TestParseDict(t *testing.T) {
 					t.Fatalf("ID: got %d, want %d", d.ID(), id)
 				}
 
-				e := NewEncoder()
-				e.AddDict(d)
+				e := mustEncoder(t, WithEncoderDict(d))
 				compressed := e.AppendCompress(nil, src)
 
-				dec := NewDecoder()
-				dec.AddDict(d)
+				dec := mustDecoder(t, WithDecoderDict(d))
 				got, err := dec.AppendDecompress(nil, compressed)
 				if err != nil {
 					t.Fatal(err)
@@ -250,7 +248,7 @@ func TestDict_MarshalBinary(t *testing.T) {
 	}
 }
 
-func TestEncoder_SetRawDict(t *testing.T) {
+func TestWithEncoderRawDict(t *testing.T) {
 	t.Run("round_trip_all_levels", func(t *testing.T) {
 		dictContent := bytes.Repeat([]byte("dictionary prefix content here! "), 100)
 		src := append([]byte{}, dictContent[500:1500]...)
@@ -260,12 +258,7 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		for level := BestSpeed; level <= BestCompression; level++ {
 			t.Run("", func(t *testing.T) {
 				var buf bytes.Buffer
-				e := NewEncoder()
-				if err := e.SetLevel(level); err != nil {
-					t.Fatal(err)
-				}
-				e.SetRawDict(dictContent)
-				w := NewWriter(&buf, e)
+				w := mustWriter(t, &buf, WithEncoderLevel(level), WithEncoderRawDict(dictContent))
 				w.Reset(&buf)
 				if _, err := w.Write(src); err != nil {
 					t.Fatal(err)
@@ -274,9 +267,7 @@ func TestEncoder_SetRawDict(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				dec := NewDecoder()
-				dec.SetRawDict(dictContent)
-				r := NewReader(bytes.NewReader(buf.Bytes()), dec)
+				r := mustReader(t, bytes.NewReader(buf.Bytes()), WithDecoderRawDict(dictContent))
 				got, err := io.ReadAll(r)
 				if err := r.Close(); err != nil {
 					t.Fatal(err)
@@ -298,16 +289,10 @@ func TestEncoder_SetRawDict(t *testing.T) {
 
 		for level := BestSpeed; level <= BestCompression; level++ {
 			t.Run("", func(t *testing.T) {
-				e := NewEncoder()
-				if err := e.SetLevel(level); err != nil {
-					t.Fatal(err)
-				}
-				e.SetRawDict(dictContent)
+				e := mustEncoder(t, WithEncoderLevel(level), WithEncoderRawDict(dictContent))
 				compressed := e.AppendCompress(nil, src)
 
-				dec := NewDecoder()
-				dec.SetRawDict(dictContent)
-				r := NewReader(bytes.NewReader(compressed), dec)
+				r := mustReader(t, bytes.NewReader(compressed), WithDecoderRawDict(dictContent))
 				got, err := io.ReadAll(r)
 				if err := r.Close(); err != nil {
 					t.Fatal(err)
@@ -328,14 +313,11 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		src := append([]byte{}, dictContent[:2000]...)
 		src = append(src, []byte("tiny unique suffix")...)
 
-		e := NewEncoder()
-
 		// Without dict.
-		noDictCompressed := e.AppendCompress(nil, src)
+		noDictCompressed := mustEncoder(t).AppendCompress(nil, src)
 
 		// With dict.
-		e.SetRawDict(dictContent)
-		withDictCompressed := e.AppendCompress(nil, src)
+		withDictCompressed := mustEncoder(t, WithEncoderRawDict(dictContent)).AppendCompress(nil, src)
 
 		if len(withDictCompressed) > len(noDictCompressed) {
 			t.Fatalf("dict should help: with=%d, without=%d", len(withDictCompressed), len(noDictCompressed))
@@ -347,12 +329,9 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		src := append([]byte{}, dictContent[:2000]...)
 		src = append(src, []byte("unique tail")...)
 
-		e := NewEncoder()
+		noDictCompressed := mustEncoder(t).AppendCompress(nil, src)
 
-		noDictCompressed := e.AppendCompress(nil, src)
-
-		e.SetRawDict(dictContent)
-		withDictCompressed := e.AppendCompress(nil, src)
+		withDictCompressed := mustEncoder(t, WithEncoderRawDict(dictContent)).AppendCompress(nil, src)
 
 		if len(withDictCompressed) >= len(noDictCompressed) {
 			t.Fatalf("dict should shrink output: with=%d, without=%d", len(withDictCompressed), len(noDictCompressed))
@@ -364,13 +343,10 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		for _, sz := range []int{8, 16} {
 			t.Run("", func(t *testing.T) {
 				dictContent := bytes.Repeat([]byte("x"), sz)
-				e := NewEncoder()
-				e.SetRawDict(dictContent)
+				e := mustEncoder(t, WithEncoderRawDict(dictContent))
 				compressed := e.AppendCompress(nil, src)
 
-				dec := NewDecoder()
-				dec.SetRawDict(dictContent)
-				r := NewReader(bytes.NewReader(compressed), dec)
+				r := mustReader(t, bytes.NewReader(compressed), WithDecoderRawDict(dictContent))
 				got, err := io.ReadAll(r)
 				_ = r.Close()
 				if err != nil {
@@ -387,14 +363,12 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		src := bytes.Repeat([]byte("short dict ignored "), 50)
 
 		// Compress without dict.
-		e := NewEncoder()
-		want := e.AppendCompress(nil, src)
+		want := mustEncoder(t).AppendCompress(nil, src)
 
-		// SetRawDict with < 8 bytes should be silently ignored.
+		// WithEncoderRawDict with < 8 bytes should be silently ignored.
 		for _, sz := range []int{1, 4, 7} {
 			t.Run("", func(t *testing.T) {
-				e2 := NewEncoder()
-				e2.SetRawDict(bytes.Repeat([]byte("x"), sz))
+				e2 := mustEncoder(t, WithEncoderRawDict(bytes.Repeat([]byte("x"), sz)))
 				got := e2.AppendCompress(nil, src)
 				if !bytes.Equal(got, want) {
 					t.Fatalf("sz=%d: short dict was not ignored (output differs)", sz)
@@ -403,8 +377,7 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		}
 
 		// Reader side: short dict should not register.
-		dec := NewDecoder()
-		dec.SetRawDict(bytes.Repeat([]byte("x"), 3))
+		dec := mustDecoder(t, WithDecoderRawDict(bytes.Repeat([]byte("x"), 3)))
 		got, err := dec.AppendDecompress(nil, want)
 		if err != nil {
 			t.Fatal(err)
@@ -419,16 +392,13 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		src := bytes.Repeat([]byte("data "), 100)
 
 		// Compress with dict.
-		e := NewEncoder()
-		e.SetRawDict(dictContent)
-		withDict := e.AppendCompress(nil, src)
+		withDict := mustEncoder(t, WithEncoderRawDict(dictContent)).AppendCompress(nil, src)
 
-		// Short dict should be a no-op — dict stays.
-		e.SetRawDict([]byte("x"))
-		stillWithDict := e.AppendCompress(nil, src)
+		// A short raw dict is a no-op — the real dict remains.
+		stillWithDict := mustEncoder(t, WithEncoderRawDict(dictContent), WithEncoderRawDict([]byte("x"))).AppendCompress(nil, src)
 
 		if !bytes.Equal(withDict, stillWithDict) {
-			t.Fatal("short SetRawDict should not have cleared dict")
+			t.Fatal("short WithEncoderRawDict should not have cleared dict")
 		}
 	})
 
@@ -437,10 +407,7 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		src := []byte("hello world, compressed without dict")
 
 		var buf bytes.Buffer
-		e := NewEncoder()
-		e.SetRawDict(dictContent)
-		e.SetRawDict(nil) // clear dict
-		w := NewWriter(&buf, e)
+		w := mustWriter(t, &buf, WithEncoderRawDict(dictContent), WithEncoderRawDict(nil)) // second option clears dict
 		w.Reset(&buf)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
@@ -449,7 +416,7 @@ func TestEncoder_SetRawDict(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -465,10 +432,7 @@ func TestEncoder_SetRawDict(t *testing.T) {
 		src := []byte("hello world, compressed without dict")
 
 		var buf bytes.Buffer
-		e := NewEncoder()
-		e.SetRawDict(dictContent)
-		e.AddDict(nil) // clear dict
-		w := NewWriter(&buf, e)
+		w := mustWriter(t, &buf, WithEncoderRawDict(dictContent), WithEncoderDict(nil)) // second option clears dict
 		w.Reset(&buf)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
@@ -477,7 +441,7 @@ func TestEncoder_SetRawDict(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -500,13 +464,10 @@ func TestEncoder_SetRawDict(t *testing.T) {
 			src  []byte
 		}{{"frame1", src1}, {"frame2", src2}} {
 			t.Run(frame.name, func(t *testing.T) {
-				e := NewEncoder()
-				e.SetRawDict(dictContent)
+				e := mustEncoder(t, WithEncoderRawDict(dictContent))
 				compressed := e.AppendCompress(nil, frame.src)
 
-				dec := NewDecoder()
-				dec.SetRawDict(dictContent)
-				r := NewReader(bytes.NewReader(compressed), dec)
+				r := mustReader(t, bytes.NewReader(compressed), WithDecoderRawDict(dictContent))
 				got, err := io.ReadAll(r)
 				_ = r.Close()
 				if err != nil {
@@ -520,7 +481,7 @@ func TestEncoder_SetRawDict(t *testing.T) {
 	})
 }
 
-func TestEncoder_AddDict(t *testing.T) {
+func TestWithEncoderDict(t *testing.T) {
 	t.Run("round_trip", func(t *testing.T) {
 		raw := loadTestDict(t)
 		d, err := ParseDict(raw)
@@ -531,16 +492,10 @@ func TestEncoder_AddDict(t *testing.T) {
 
 		for level := BestSpeed; level <= BestCompression; level++ {
 			t.Run("", func(t *testing.T) {
-				e := NewEncoder()
-				if err := e.SetLevel(level); err != nil {
-					t.Fatal(err)
-				}
-				e.AddDict(d)
+				e := mustEncoder(t, WithEncoderLevel(level), WithEncoderDict(d))
 				compressed := e.AppendCompress(nil, src)
 
-				dec := NewDecoder()
-				dec.AddDict(d)
-				r := NewReader(bytes.NewReader(compressed), dec)
+				r := mustReader(t, bytes.NewReader(compressed), WithDecoderDict(d))
 				got, err := io.ReadAll(r)
 				if err := r.Close(); err != nil {
 					t.Fatal(err)
@@ -564,9 +519,7 @@ func TestEncoder_AddDict(t *testing.T) {
 		src := bytes.Repeat([]byte("streaming parsed dict test "), 300)
 
 		var buf bytes.Buffer
-		e := NewEncoder()
-		e.AddDict(d)
-		w := NewWriter(&buf, e)
+		w := mustWriter(t, &buf, WithEncoderDict(d))
 		w.Reset(&buf)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
@@ -575,9 +528,7 @@ func TestEncoder_AddDict(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		dec := NewDecoder()
-		dec.AddDict(d)
-		r := NewReader(bytes.NewReader(buf.Bytes()), dec)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()), WithDecoderDict(d))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -597,13 +548,10 @@ func TestEncoder_AddDict(t *testing.T) {
 		// > 128KB to force multiple blocks.
 		src := bytes.Repeat([]byte("multiblock dict content xyz "), 6000)
 
-		e := NewEncoder()
-		e.AddDict(d)
+		e := mustEncoder(t, WithEncoderDict(d))
 		compressed := e.AppendCompress(nil, src)
 
-		dec := NewDecoder()
-		dec.AddDict(d)
-		r := NewReader(bytes.NewReader(compressed), dec)
+		r := mustReader(t, bytes.NewReader(compressed), WithDecoderDict(d))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -622,12 +570,10 @@ func TestEncoder_AddDict(t *testing.T) {
 		}
 		src := bytes.Repeat([]byte("decode-all parsed dict test "), 100)
 
-		e := NewEncoder()
-		e.AddDict(d)
+		e := mustEncoder(t, WithEncoderDict(d))
 		compressed := e.AppendCompress(nil, src)
 
-		dec := NewDecoder()
-		dec.AddDict(d)
+		dec := mustDecoder(t, WithDecoderDict(d))
 		got, err := dec.AppendDecompress(nil, compressed)
 		if err != nil {
 			t.Fatal(err)
@@ -638,7 +584,7 @@ func TestEncoder_AddDict(t *testing.T) {
 	})
 }
 
-func TestDecoder_SetRawDict(t *testing.T) {
+func TestWithDecoderRawDict(t *testing.T) {
 	t.Run("nil_clear", func(t *testing.T) {
 		raw := loadTestDict(t)
 		d, err := ParseDict(raw)
@@ -647,13 +593,10 @@ func TestDecoder_SetRawDict(t *testing.T) {
 		}
 		src := bytes.Repeat([]byte("reader raw dict nil clear "), 50)
 
-		e := NewEncoder()
-		e.AddDict(d)
+		e := mustEncoder(t, WithEncoderDict(d))
 		compressed := e.AppendCompress(nil, src)
 
-		dec := NewDecoder()
-		dec.AddDict(d)
-		r := NewReader(bytes.NewReader(compressed), dec)
+		r := mustReader(t, bytes.NewReader(compressed), WithDecoderDict(d))
 		got, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
@@ -662,10 +605,8 @@ func TestDecoder_SetRawDict(t *testing.T) {
 			t.Fatal("mismatch before clear")
 		}
 
-		dec.SetRawDict(nil) // clear all dicts
-		if err := r.Reset(bytes.NewReader(compressed)); err != nil {
-			t.Fatal(err)
-		}
+		// A fresh reader with no dict registered must fail.
+		r = mustReader(t, bytes.NewReader(compressed))
 		_, err = io.ReadAll(r)
 		_ = r.Close()
 		if err != ErrUnknownDictionary {
@@ -677,15 +618,11 @@ func TestDecoder_SetRawDict(t *testing.T) {
 		dictContent := bytes.Repeat([]byte("real dict content "), 50)
 		src := bytes.Repeat([]byte("data "), 100)
 
-		e := NewEncoder()
-		e.SetRawDict(dictContent)
+		e := mustEncoder(t, WithEncoderRawDict(dictContent))
 		compressed := e.AppendCompress(nil, src)
 
-		dec := NewDecoder()
-		dec.SetRawDict(dictContent)
-
-		// Short dict should be a no-op — real dict stays.
-		dec.SetRawDict([]byte("short"))
+		// The short raw dict is a no-op, so the real dict remains.
+		dec := mustDecoder(t, WithDecoderRawDict(dictContent), WithDecoderRawDict([]byte("short")))
 
 		got, err := dec.AppendDecompress(nil, compressed)
 		if err != nil {
@@ -700,12 +637,10 @@ func TestDecoder_SetRawDict(t *testing.T) {
 		dict := []byte("12345678")
 		src := bytes.Repeat([]byte("exactly8 "), 100)
 
-		e := NewEncoder()
-		e.SetRawDict(dict)
+		e := mustEncoder(t, WithEncoderRawDict(dict))
 		compressed := e.AppendCompress(nil, src)
 
-		dec := NewDecoder()
-		dec.SetRawDict(dict)
+		dec := mustDecoder(t, WithDecoderRawDict(dict))
 		got, err := dec.AppendDecompress(nil, compressed)
 		if err != nil {
 			t.Fatal(err)
@@ -724,16 +659,13 @@ func TestDecoder_SetRawDict(t *testing.T) {
 
 		// Compress each frame with its own writer to avoid writer reuse issues.
 		compress := func(src []byte) []byte {
-			e := NewEncoder()
-			e.SetRawDict(dictContent)
+			e := mustEncoder(t, WithEncoderRawDict(dictContent))
 			return e.AppendCompress(nil, src)
 		}
 		comp1 := compress(src1)
 		comp2 := compress(src2)
 
-		dec := NewDecoder()
-		dec.SetRawDict(dictContent)
-		r := NewReader(bytes.NewReader(comp1), dec)
+		r := mustReader(t, bytes.NewReader(comp1), WithDecoderRawDict(dictContent))
 		got1, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
@@ -762,18 +694,12 @@ func TestDecoder_SetRawDict(t *testing.T) {
 		dict2 := bytes.Repeat([]byte("dict two content "), 50)
 		src := bytes.Repeat([]byte("payload "), 100)
 
-		e1 := NewEncoder()
-		e1.SetRawDict(dict1)
-		frame1 := e1.AppendCompress(nil, src)
+		frame1 := mustEncoder(t, WithEncoderRawDict(dict1)).AppendCompress(nil, src)
 
-		e2 := NewEncoder()
-		e2.SetRawDict(dict2)
-		frame2 := e2.AppendCompress(nil, src)
+		frame2 := mustEncoder(t, WithEncoderRawDict(dict2)).AppendCompress(nil, src)
 
 		// Reader switches dicts between frames.
-		dec := NewDecoder()
-		dec.SetRawDict(dict1)
-		r := NewReader(bytes.NewReader(frame1), dec)
+		r := mustReader(t, bytes.NewReader(frame1), WithDecoderRawDict(dict1))
 		got1, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
@@ -782,10 +708,7 @@ func TestDecoder_SetRawDict(t *testing.T) {
 			t.Fatal("frame 1 mismatch")
 		}
 
-		dec.SetRawDict(dict2)
-		if err := r.Reset(bytes.NewReader(frame2)); err != nil {
-			t.Fatal(err)
-		}
+		r = mustReader(t, bytes.NewReader(frame2), WithDecoderRawDict(dict2))
 		got2, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -797,7 +720,7 @@ func TestDecoder_SetRawDict(t *testing.T) {
 	})
 }
 
-func TestDecoder_AddDict(t *testing.T) {
+func TestWithDecoderDict(t *testing.T) {
 	t.Run("nil_clear", func(t *testing.T) {
 		raw := loadTestDict(t)
 		d, err := ParseDict(raw)
@@ -806,13 +729,10 @@ func TestDecoder_AddDict(t *testing.T) {
 		}
 		src := bytes.Repeat([]byte("reader add dict nil clear "), 50)
 
-		e := NewEncoder()
-		e.AddDict(d)
+		e := mustEncoder(t, WithEncoderDict(d))
 		compressed := e.AppendCompress(nil, src)
 
-		dec := NewDecoder()
-		dec.AddDict(d)
-		r := NewReader(bytes.NewReader(compressed), dec)
+		r := mustReader(t, bytes.NewReader(compressed), WithDecoderDict(d))
 		got, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
@@ -821,10 +741,8 @@ func TestDecoder_AddDict(t *testing.T) {
 			t.Fatal("mismatch before clear")
 		}
 
-		dec.AddDict(nil)
-		if err := r.Reset(bytes.NewReader(compressed)); err != nil {
-			t.Fatal(err)
-		}
+		// A fresh reader with no dict registered must fail.
+		r = mustReader(t, bytes.NewReader(compressed))
 		_, err = io.ReadAll(r)
 		_ = r.Close()
 		if err != ErrUnknownDictionary {
@@ -853,20 +771,14 @@ func TestDecoder_AddDict(t *testing.T) {
 		srcA := bytes.Repeat([]byte("frame A data "), 100)
 		srcB := bytes.Repeat([]byte("frame B data "), 100)
 
-		eA := NewEncoder()
-		eA.AddDict(dA)
-		compA := eA.AppendCompress(nil, srcA)
+		compA := mustEncoder(t, WithEncoderDict(dA)).AppendCompress(nil, srcA)
 
-		eB := NewEncoder()
-		eB.AddDict(dB)
-		compB := eB.AppendCompress(nil, srcB)
+		compB := mustEncoder(t, WithEncoderDict(dB)).AppendCompress(nil, srcB)
 
 		// Concatenate two frames.
 		combined := append(compA, compB...)
 
-		dec := NewDecoder()
-		dec.AddDict(dA)
-		dec.AddDict(dB)
+		dec := mustDecoder(t, WithDecoderDict(dA), WithDecoderDict(dB))
 		got, err := dec.AppendDecompress(nil, combined)
 		if err != nil {
 			t.Fatal(err)
@@ -887,18 +799,12 @@ func TestDecoder_AddDict(t *testing.T) {
 		src := bytes.Repeat([]byte("multi dict clear test "), 50)
 
 		// Compress with parsed dict.
-		eParsed := NewEncoder()
-		eParsed.AddDict(d)
-		compParsed := eParsed.AppendCompress(nil, src)
+		compParsed := mustEncoder(t, WithEncoderDict(d)).AppendCompress(nil, src)
 
 		// Compress with raw dict.
-		eRaw := NewEncoder()
-		eRaw.SetRawDict(dictContent)
-		compRaw := eRaw.AppendCompress(nil, src)
+		compRaw := mustEncoder(t, WithEncoderRawDict(dictContent)).AppendCompress(nil, src)
 
-		dec := NewDecoder()
-		dec.AddDict(d)
-		dec.SetRawDict(dictContent)
+		dec := mustDecoder(t, WithDecoderDict(d), WithDecoderRawDict(dictContent))
 
 		// Both should decode.
 		got, err := dec.AppendDecompress(nil, compParsed)
@@ -916,13 +822,14 @@ func TestDecoder_AddDict(t *testing.T) {
 			t.Fatal("raw dict mismatch")
 		}
 
-		dec.AddDict(nil) // clear all
+		// A fresh decoder with no dicts registered must fail.
+		noDict := mustDecoder(t)
 
-		_, err = dec.AppendDecompress(nil, compParsed)
+		_, err = noDict.AppendDecompress(nil, compParsed)
 		if err != ErrUnknownDictionary {
 			t.Fatalf("parsed dict after clear: expected ErrUnknownDictionary, got: %v", err)
 		}
-		_, err = dec.AppendDecompress(nil, compRaw)
+		_, err = noDict.AppendDecompress(nil, compRaw)
 		// Raw dict (ID 0) doesn't embed a dict ID in the frame, so the error
 		// is a corruption from bad offsets rather than ErrUnknownDictionary.
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -936,12 +843,9 @@ func TestNoDictDecodeWithDict(t *testing.T) {
 	src := bytes.Repeat([]byte("no dict needed "), 200)
 	dictContent := []byte("some dict content that is not used")
 
-	e := NewEncoder()
-	compressed := e.AppendCompress(nil, src)
+	compressed := mustEncoder(t).AppendCompress(nil, src)
 
-	dec := NewDecoder()
-	dec.SetRawDict(dictContent)
-	r := NewReader(bytes.NewReader(compressed), dec)
+	r := mustReader(t, bytes.NewReader(compressed), WithDecoderRawDict(dictContent))
 	got, err := io.ReadAll(r)
 	if err := r.Close(); err != nil {
 		t.Fatal(err)
@@ -962,12 +866,11 @@ func TestDictIDMismatch(t *testing.T) {
 	}
 	src := bytes.Repeat([]byte("dict id mismatch test "), 50)
 
-	e := NewEncoder()
-	e.AddDict(d)
+	e := mustEncoder(t, WithEncoderDict(d))
 	compressed := e.AppendCompress(nil, src)
 
 	// Decode without dict registered → ErrUnknownDictionary.
-	r := NewReader(bytes.NewReader(compressed), nil)
+	r := mustReader(t, bytes.NewReader(compressed))
 	_, err = io.ReadAll(r)
 	_ = r.Close()
 	if err != ErrUnknownDictionary {
@@ -975,7 +878,7 @@ func TestDictIDMismatch(t *testing.T) {
 	}
 
 	// Also test DecodeBytes path.
-	dec := NewDecoder()
+	dec := mustDecoder(t)
 	_, err = dec.AppendDecompress(nil, compressed)
 	if err != ErrUnknownDictionary {
 		t.Fatalf("DecodeBytes: expected ErrUnknownDictionary, got: %v", err)

--- a/encoder.go
+++ b/encoder.go
@@ -7,11 +7,353 @@ package zstd
 import (
 	"fmt"
 	"io"
+	"math"
 	"math/bits"
+	"sync"
 
 	"github.com/klauspost/stdgozstd/internal/le"
 	"github.com/klauspost/stdgozstd/internal/xxhash"
 )
+
+// Compression level constants. These map to the levels accepted by
+// [Encoder.SetLevel].
+const (
+	DefaultCompression = -1 // level 3
+	NoCompression      = 0  // store blocks without compression
+	BestSpeed          = 1  // lowest compression, fastest speed
+	BestCompression    = 9  // highest compression, slowest speed
+)
+
+// encoderPools caches encoders by category to avoid repeated hash table allocation.
+var encoderPools [5]sync.Pool
+
+// putEncoder returns an encoder to its pool for reuse.
+func putEncoder(enc encoder) {
+	switch enc.(type) {
+	case *rawEncoder:
+		encoderPools[0].Put(enc)
+	case *fastEncoder:
+		encoderPools[1].Put(enc)
+	case *doubleFastEncoder:
+		encoderPools[2].Put(enc)
+	case *betterFastEncoder:
+		encoderPools[3].Put(enc)
+	case *bestFastEncoder:
+		encoderPools[4].Put(enc)
+	}
+}
+
+// encoderCategory maps a compression level to a pool index (0-4).
+func encoderCategory(level int) int {
+	switch {
+	case level == 0:
+		return 0
+	case level <= 2:
+		return 1
+	case level <= 4:
+		return 2
+	case level <= 7:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// Encoder holds compression configuration and provides one-shot compression
+// via [Encoder.AppendCompress]. A single Encoder may be passed to any number
+// of [NewWriter] calls; it must not be reconfigured while a bound Writer is
+// mid-stream.
+type Encoder struct {
+	level     int
+	blockSize int
+	wndSize   int
+	crc       bool
+	lowMem    bool
+
+	dict        *dict
+	initialized bool
+}
+
+// ensureInit lazily applies default configuration on first use.
+func (e *Encoder) ensureInit() {
+	if e.initialized {
+		return
+	}
+	e.initialized = true
+	initPredefined()
+	e.level = 3
+	e.blockSize = maxCompressedBlockSize
+	e.wndSize = 4 << 20
+	e.crc = true
+}
+
+// NewEncoder returns a new Encoder configured for the default compression level.
+func NewEncoder() *Encoder {
+	e := &Encoder{}
+	e.ensureInit()
+	return e
+}
+
+// SetLevel sets the compression level. Valid values range from
+// [NoCompression] (0) to [BestCompression] (9); [DefaultCompression] (-1)
+// selects level 3.
+func (e *Encoder) SetLevel(level int) error {
+	e.ensureInit()
+	if level == DefaultCompression {
+		level = 3
+	}
+	if level < NoCompression || level > BestCompression {
+		return fmt.Errorf("zstd: invalid level %d", level)
+	}
+	e.level = level
+	e.blockSize = maxCompressedBlockSize
+	// These mirror zstd default window sizes at levels 1, 3 and 9.
+	switch level {
+	case 0:
+		e.wndSize = 0
+	case 1:
+		e.wndSize = 2 << 20
+	case 2:
+		e.wndSize = 3 << 20
+	case 3:
+		e.wndSize = 4 << 20
+	case 4:
+		e.wndSize = 4 << 20
+	case 5:
+		e.wndSize = 4 << 20
+	case 6:
+		e.wndSize = 5 << 20
+	case 7:
+		e.wndSize = 6 << 20
+	case 8:
+		e.wndSize = 7 << 20
+	case 9:
+		e.wndSize = 8 << 20
+	}
+	return nil
+}
+
+// SetWindowSize overrides the window size for compression.
+// This allows limiting memory usage both for compression and decompression.
+//
+// n must be in the range [MinWindowSize, MaxWindowSize].
+func (e *Encoder) SetWindowSize(n int) error {
+	e.ensureInit()
+	if n < MinWindowSize || n > MaxWindowSize {
+		return fmt.Errorf("zstd: window size %d out of range [%d, %d]", n, MinWindowSize, MaxWindowSize)
+	}
+	e.wndSize = n
+	return nil
+}
+
+// SetLowMemory controls whether the encoder should trade speed for
+// lower memory usage.
+func (e *Encoder) SetLowMemory(b bool) {
+	e.ensureInit()
+	e.lowMem = b
+}
+
+// SetCRC controls whether a xxHash-64 checksum is appended to each frame.
+// The default is true.
+func (e *Encoder) SetCRC(b bool) {
+	e.ensureInit()
+	e.crc = b
+}
+
+// AddDict registers a parsed dictionary for compression.
+// Passing nil removes the previous dictionary.
+func (e *Encoder) AddDict(d *Dict) {
+	e.ensureInit()
+	if d == nil {
+		e.dict = nil
+		return
+	}
+	e.dict = d.d
+}
+
+// SetRawDict registers raw bytes as a dictionary prefix.
+// The dictionary must be at least 8 bytes; shorter non-nil values are ignored.
+// Passing nil removes any previous dictionary.
+func (e *Encoder) SetRawDict(b []byte) {
+	e.ensureInit()
+	if b == nil {
+		e.dict = nil
+		return
+	}
+	if len(b) < 8 {
+		return
+	}
+	e.dict = &dict{content: b}
+}
+
+// newEncoder creates the appropriate encoder for the current level,
+// pulling from a pool when possible to avoid hash table allocation.
+func (e *Encoder) newEncoder() encoder {
+	maxOff := int32(e.wndSize)
+	if maxOff == 0 {
+		maxOff = 4 << 20
+	}
+	bufReset := math.MaxInt32 - maxOff*2
+	cat := encoderCategory(e.level)
+
+	if v := encoderPools[cat].Get(); v != nil {
+		enc := v.(encoder)
+		enc.configure(maxOff, bufReset, e.lowMem)
+		return enc
+	}
+
+	switch {
+	case e.level == 0:
+		en := &rawEncoder{}
+		en.configure(maxOff, bufReset, e.lowMem)
+		return en
+	case e.level <= 2:
+		en := &fastEncoder{}
+		en.configure(maxOff, bufReset, e.lowMem)
+		return en
+	case e.level <= 4:
+		en := &doubleFastEncoder{}
+		en.configure(maxOff, bufReset, e.lowMem)
+		return en
+	case e.level <= 7:
+		en := &betterFastEncoder{}
+		en.configure(maxOff, bufReset, e.lowMem)
+		return en
+	default:
+		en := &bestFastEncoder{}
+		en.configure(maxOff, bufReset, e.lowMem)
+		return en
+	}
+}
+
+// AppendCompress compresses src as a single zstd frame and appends the result to
+// dst, returning the extended buffer. It is a one-shot alternative to the
+// streaming [Writer] interface.
+//
+// The Encoder's current level, dictionary, CRC, and window-size settings apply.
+// The returned frame is self-contained: it includes a frame header, one or more
+// blocks, and an optional checksum.
+//
+// Passing nil for dst allocates a new slice. Passing a non-nil dst (e.g. buf[:0])
+// lets the caller reuse memory. Multiple calls may be made to concatenate frames:
+//
+//	var frames []byte
+//	frames = e.AppendCompress(frames, part1)
+//	frames = e.AppendCompress(frames, part2)
+//
+// If src is nil or empty, a minimal valid frame is appended to dst.
+//
+// AppendCompress is safe for concurrent use on the same Encoder,
+// provided configuration methods are not called concurrently.
+func (e *Encoder) AppendCompress(dst, src []byte) []byte {
+	e.ensureInit()
+	enc := e.newEncoder()
+	defer putEncoder(enc)
+	return e.encodeAll(enc, src, dst)
+}
+
+// encodeAll compresses src into a single frame appended to dst.
+func (e *Encoder) encodeAll(enc encoder, src, dst []byte) []byte {
+	if len(src) == 0 {
+		fh := frameHeader{
+			ContentSize:   0,
+			WindowSize:    MinWindowSize,
+			SingleSegment: true,
+			Checksum:      e.crc,
+			DictID:        e.dict.ID(),
+		}
+		dst = fh.appendTo(dst)
+		var blk blockHeader
+		blk.setSize(0)
+		blk.setType(blockTypeRaw)
+		blk.setLast(true)
+		dst = blk.appendTo(dst)
+		if e.crc {
+			enc.reset(nil, true)
+			dst = enc.appendCRC(dst)
+		}
+		return dst
+	}
+
+	single := len(src) <= e.wndSize && len(src) > MinWindowSize
+	fh := frameHeader{
+		ContentSize:   uint64(len(src)),
+		WindowSize:    uint32(enc.windowSize(int64(len(src)))),
+		SingleSegment: single,
+		Checksum:      e.crc,
+		DictID:        e.dict.ID(),
+	}
+
+	if len(dst) == 0 && cap(dst) == 0 && len(src) < 1<<20 {
+		dst = make([]byte, 0, len(src))
+	}
+	dst = fh.appendTo(dst)
+
+	if raw, ok := enc.(rawBlockWriter); ok {
+		enc.reset(nil, true)
+		if e.crc {
+			_, _ = enc.checksum().Write(src)
+		}
+		for len(src) > 0 {
+			todo := src
+			if len(todo) > maxCompressedBlockSize {
+				todo = todo[:maxCompressedBlockSize]
+			}
+			src = src[len(todo):]
+			dst = raw.appendRaw(dst, todo, len(src) == 0)
+		}
+	} else if len(src) <= e.blockSize {
+		enc.reset(e.dict, true)
+		if e.crc {
+			_, _ = enc.checksum().Write(src)
+		}
+		blk := enc.block()
+		blk.last = true
+		if e.dict == nil {
+			enc.encodeNoHist(blk, src)
+		} else {
+			enc.encode(blk, src)
+		}
+
+		oldout := blk.output
+		blk.output = dst
+
+		err := blk.encode(src, false, true)
+		if err != nil {
+			panic(err)
+		}
+		dst = blk.output
+		blk.output = oldout
+	} else {
+		enc.reset(e.dict, false)
+		blk := enc.block()
+		for len(src) > 0 {
+			todo := src
+			if len(todo) > e.blockSize {
+				todo = todo[:e.blockSize]
+			}
+			src = src[len(todo):]
+			if e.crc {
+				_, _ = enc.checksum().Write(todo)
+			}
+			blk.pushOffsets()
+			enc.encode(blk, todo)
+			if len(src) == 0 {
+				blk.last = true
+			}
+			err := blk.encode(todo, false, true)
+			if err != nil {
+				panic(err)
+			}
+			dst = append(dst, blk.output...)
+			blk.reset(nil)
+		}
+	}
+	if e.crc {
+		dst = enc.appendCRC(dst)
+	}
+	return dst
+}
 
 // encoder is the internal interface shared by all compression encoders.
 type encoder interface {

--- a/encoder.go
+++ b/encoder.go
@@ -63,11 +63,12 @@ func encoderCategory(level int) int {
 // via [Encoder.AppendCompress]. Configuration is fixed at construction via
 // [EncoderOption] values and is immutable afterwards.
 type Encoder struct {
-	level     int
-	blockSize int
-	wndSize   int
-	crc       bool
-	lowMem    bool
+	level       int
+	blockSize   int
+	wndSize     int
+	crc         bool
+	lowMem      bool
+	contentSize int64
 
 	dict *dict
 	once sync.Once
@@ -98,8 +99,9 @@ func NewEncoder(opts ...EncoderOption) (*Encoder, error) {
 	return e, nil
 }
 
-// EncoderOption configures an [Encoder]. Options are passed to [NewEncoder] and
-// [NewWriter].
+// EncoderOption configures an [Encoder]. Options are passed to [NewEncoder],
+// [NewWriter], and [Writer.Reset]. Every option may be changed via
+// [Writer.Reset]; the new configuration applies to the next frame.
 type EncoderOption func(*Encoder) error
 
 // WithEncoderLevel sets the compression level. Valid values range from
@@ -201,6 +203,23 @@ func WithEncoderRawDict(b []byte) EncoderOption {
 			return nil
 		}
 		e.dict = &dict{content: b}
+		return nil
+	}
+}
+
+// WithContentSize declares the total uncompressed size of the stream. It is
+// written into the frame header and verified on [Writer.Close]. A negative
+// size is an error; the default, 0, marks the size as unknown.
+//
+// This applies only to the streaming [Writer]; [Encoder.AppendCompress] always
+// records the exact size. Like any option it persists across [Writer.Reset]
+// calls until changed — pass WithContentSize(0) to clear it.
+func WithContentSize(size int64) EncoderOption {
+	return func(e *Encoder) error {
+		if size < 0 {
+			return fmt.Errorf("zstd: content size %d must be >= 0", size)
+		}
+		e.contentSize = size
 		return nil
 	}
 }

--- a/encoder.go
+++ b/encoder.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Compression level constants. These map to the levels accepted by
-// [Encoder.SetLevel].
+// [WithEncoderLevel].
 const (
 	DefaultCompression = -1 // level 3
 	NoCompression      = 0  // store blocks without compression
@@ -60,9 +60,8 @@ func encoderCategory(level int) int {
 }
 
 // Encoder holds compression configuration and provides one-shot compression
-// via [Encoder.AppendCompress]. A single Encoder may be passed to any number
-// of [NewWriter] calls; it must not be reconfigured while a bound Writer is
-// mid-stream.
+// via [Encoder.AppendCompress]. Configuration is fixed at construction via
+// [EncoderOption] values and is immutable afterwards.
 type Encoder struct {
 	level     int
 	blockSize int
@@ -85,103 +84,125 @@ func (e *Encoder) ensureInit() {
 	})
 }
 
-// NewEncoder returns a new Encoder configured for the default compression level.
-func NewEncoder() *Encoder {
+// NewEncoder returns a new Encoder configured by opts. Options are applied in
+// order; a later option overrides an earlier one. With no options the Encoder
+// uses the default compression level.
+func NewEncoder(opts ...EncoderOption) (*Encoder, error) {
 	e := &Encoder{}
 	e.ensureInit()
-	return e
+	for _, o := range opts {
+		if err := o(e); err != nil {
+			return nil, err
+		}
+	}
+	return e, nil
 }
 
-// SetLevel sets the compression level. Valid values range from
+// EncoderOption configures an [Encoder]. Options are passed to [NewEncoder] and
+// [NewWriter].
+type EncoderOption func(*Encoder) error
+
+// WithEncoderLevel sets the compression level. Valid values range from
 // [NoCompression] (0) to [BestCompression] (9); [DefaultCompression] (-1)
 // selects level 3.
-func (e *Encoder) SetLevel(level int) error {
-	e.ensureInit()
-	if level == DefaultCompression {
-		level = 3
+func WithEncoderLevel(level int) EncoderOption {
+	return func(e *Encoder) error {
+		if level == DefaultCompression {
+			level = 3
+		}
+		if level < NoCompression || level > BestCompression {
+			return fmt.Errorf("zstd: invalid level %d", level)
+		}
+		e.level = level
+		e.blockSize = maxCompressedBlockSize
+		// These mirror zstd default window sizes at levels 1, 3 and 9.
+		switch level {
+		case 0:
+			e.wndSize = 0
+		case 1:
+			e.wndSize = 2 << 20
+		case 2:
+			e.wndSize = 3 << 20
+		case 3:
+			e.wndSize = 4 << 20
+		case 4:
+			e.wndSize = 4 << 20
+		case 5:
+			e.wndSize = 4 << 20
+		case 6:
+			e.wndSize = 5 << 20
+		case 7:
+			e.wndSize = 6 << 20
+		case 8:
+			e.wndSize = 7 << 20
+		case 9:
+			e.wndSize = 8 << 20
+		}
+		return nil
 	}
-	if level < NoCompression || level > BestCompression {
-		return fmt.Errorf("zstd: invalid level %d", level)
-	}
-	e.level = level
-	e.blockSize = maxCompressedBlockSize
-	// These mirror zstd default window sizes at levels 1, 3 and 9.
-	switch level {
-	case 0:
-		e.wndSize = 0
-	case 1:
-		e.wndSize = 2 << 20
-	case 2:
-		e.wndSize = 3 << 20
-	case 3:
-		e.wndSize = 4 << 20
-	case 4:
-		e.wndSize = 4 << 20
-	case 5:
-		e.wndSize = 4 << 20
-	case 6:
-		e.wndSize = 5 << 20
-	case 7:
-		e.wndSize = 6 << 20
-	case 8:
-		e.wndSize = 7 << 20
-	case 9:
-		e.wndSize = 8 << 20
-	}
-	return nil
 }
 
-// SetWindowSize overrides the window size for compression.
+// WithWindowSize overrides the window size for compression.
 // This allows limiting memory usage both for compression and decompression.
+// Apply it after [WithEncoderLevel] to override the level's default window.
 //
 // n must be in the range [MinWindowSize, MaxWindowSize].
-func (e *Encoder) SetWindowSize(n int) error {
-	e.ensureInit()
-	if n < MinWindowSize || n > MaxWindowSize {
-		return fmt.Errorf("zstd: window size %d out of range [%d, %d]", n, MinWindowSize, MaxWindowSize)
+func WithWindowSize(n int) EncoderOption {
+	return func(e *Encoder) error {
+		if n < MinWindowSize || n > MaxWindowSize {
+			return fmt.Errorf("zstd: window size %d out of range [%d, %d]", n, MinWindowSize, MaxWindowSize)
+		}
+		e.wndSize = n
+		return nil
 	}
-	e.wndSize = n
-	return nil
 }
 
-// SetLowMemory controls whether the encoder should trade speed for
+// WithLowMemory controls whether the encoder should trade speed for
 // lower memory usage.
-func (e *Encoder) SetLowMemory(b bool) {
-	e.ensureInit()
-	e.lowMem = b
-}
-
-// SetCRC controls whether a xxHash-64 checksum is appended to each frame.
-// The default is true.
-func (e *Encoder) SetCRC(b bool) {
-	e.ensureInit()
-	e.crc = b
-}
-
-// AddDict registers a parsed dictionary for compression.
-// Passing nil removes the previous dictionary.
-func (e *Encoder) AddDict(d *Dict) {
-	e.ensureInit()
-	if d == nil {
-		e.dict = nil
-		return
+func WithLowMemory(b bool) EncoderOption {
+	return func(e *Encoder) error {
+		e.lowMem = b
+		return nil
 	}
-	e.dict = d.d
 }
 
-// SetRawDict registers raw bytes as a dictionary prefix.
+// WithEncoderCRC controls whether a xxHash-64 checksum is appended to each
+// frame. The default is true.
+func WithEncoderCRC(b bool) EncoderOption {
+	return func(e *Encoder) error {
+		e.crc = b
+		return nil
+	}
+}
+
+// WithEncoderDict registers a parsed dictionary for compression.
+// Passing nil removes any previously configured dictionary.
+func WithEncoderDict(d *Dict) EncoderOption {
+	return func(e *Encoder) error {
+		if d == nil {
+			e.dict = nil
+			return nil
+		}
+		e.dict = d.d
+		return nil
+	}
+}
+
+// WithEncoderRawDict registers raw bytes as a dictionary prefix.
 // The dictionary must be at least 8 bytes; shorter non-nil values are ignored.
-// Passing nil removes any previous dictionary.
-func (e *Encoder) SetRawDict(b []byte) {
-	e.ensureInit()
-	if b == nil {
-		e.dict = nil
-		return
+// Passing nil removes any previously configured dictionary.
+func WithEncoderRawDict(b []byte) EncoderOption {
+	return func(e *Encoder) error {
+		if b == nil {
+			e.dict = nil
+			return nil
+		}
+		if len(b) < 8 {
+			return nil
+		}
+		e.dict = &dict{content: b}
+		return nil
 	}
-	if len(b) < 8 {
-		return
-	}
-	e.dict = &dict{content: b}
 }
 
 // newEncoder creates the appropriate encoder for the current level,
@@ -228,7 +249,7 @@ func (e *Encoder) newEncoder() encoder {
 // dst, returning the extended buffer. It is a one-shot alternative to the
 // streaming [Writer] interface.
 //
-// The Encoder's current level, dictionary, CRC, and window-size settings apply.
+// The Encoder's configured level, dictionary, CRC, and window-size settings apply.
 // The returned frame is self-contained: it includes a frame header, one or more
 // blocks, and an optional checksum.
 //
@@ -241,8 +262,7 @@ func (e *Encoder) newEncoder() encoder {
 //
 // If src is nil or empty, a minimal valid frame is appended to dst.
 //
-// AppendCompress is safe for concurrent use on the same Encoder,
-// provided configuration methods are not called concurrently.
+// AppendCompress is safe for concurrent use on the same Encoder.
 func (e *Encoder) AppendCompress(dst, src []byte) []byte {
 	e.ensureInit()
 	enc := e.newEncoder()

--- a/encoder.go
+++ b/encoder.go
@@ -70,21 +70,19 @@ type Encoder struct {
 	crc       bool
 	lowMem    bool
 
-	dict        *dict
-	initialized bool
+	dict *dict
+	once sync.Once
 }
 
 // ensureInit lazily applies default configuration on first use.
 func (e *Encoder) ensureInit() {
-	if e.initialized {
-		return
-	}
-	e.initialized = true
-	initPredefined()
-	e.level = 3
-	e.blockSize = maxCompressedBlockSize
-	e.wndSize = 4 << 20
-	e.crc = true
+	e.once.Do(func() {
+		initPredefined()
+		e.level = 3
+		e.blockSize = maxCompressedBlockSize
+		e.wndSize = 4 << 20
+		e.crc = true
+	})
 }
 
 // NewEncoder returns a new Encoder configured for the default compression level.

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -69,61 +69,372 @@ func TestMatchLen(t *testing.T) {
 	}
 }
 
-func TestAppendCompressConcurrent(t *testing.T) {
-	src := bytes.Repeat([]byte("concurrent compress test data! "), 500)
-	e := NewEncoder()
+func TestEncoder_AppendCompress(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		src := bytes.Repeat([]byte("encode all test data! "), 500)
+		e := NewEncoder()
+		compressed := e.AppendCompress(nil, src)
 
-	const goroutines = 8
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	errs := make(chan error, goroutines)
+		r := NewReader(bytes.NewReader(compressed), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("AppendCompress round-trip mismatch")
+		}
+	})
 
-	for range goroutines {
-		go func() {
-			defer wg.Done()
-			compressed := e.AppendCompress(nil, src)
-			r := NewReader(bytes.NewReader(compressed), nil)
-			defer r.Close()
+	t.Run("empty", func(t *testing.T) {
+		e := NewEncoder()
+		c1 := e.AppendCompress(nil, nil)
+		c2 := e.AppendCompress(nil, []byte{})
+		if len(c1) == 0 {
+			t.Fatal("expected non-empty frame for nil input")
+		}
+		if !bytes.Equal(c1, c2) {
+			t.Fatal("nil and empty should produce identical frames")
+		}
+		r := NewReader(bytes.NewReader(c1), nil)
+		defer r.Close()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected empty decode, got %d bytes", len(got))
+		}
+	})
+
+	t.Run("empty_crc", func(t *testing.T) {
+		e := NewEncoder()
+		e.SetCRC(true)
+		frame := e.AppendCompress(nil, nil)
+
+		var d Decoder
+		got, err := d.AppendDecompress(nil, frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected empty, got %d bytes", len(got))
+		}
+
+		// Verify CRC is present: frame with CRC should be longer than without.
+		e.SetCRC(false)
+		noCRC := e.AppendCompress(nil, nil)
+		if len(frame) <= len(noCRC) {
+			t.Fatalf("empty CRC frame (%d) should be longer than no-CRC (%d)", len(frame), len(noCRC))
+		}
+	})
+
+	t.Run("empty_no_crc", func(t *testing.T) {
+		e := NewEncoder()
+		e.SetCRC(false)
+		frame := e.AppendCompress(nil, nil)
+
+		var d Decoder
+		got, err := d.AppendDecompress(nil, frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected empty, got %d bytes", len(got))
+		}
+	})
+
+	t.Run("multi_block", func(t *testing.T) {
+		src := make([]byte, maxCompressedBlockSize*2+1000)
+		for i := range src {
+			src[i] = byte(i % 200)
+		}
+		e := NewEncoder()
+		compressed := e.AppendCompress(nil, src)
+
+		r := NewReader(bytes.NewReader(compressed), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("AppendCompress multi-block round-trip mismatch")
+		}
+	})
+
+	t.Run("pre_existing_dst", func(t *testing.T) {
+		src := []byte("data to compress")
+		e := NewEncoder()
+		prefix := []byte("HEADER:")
+		got := e.AppendCompress(prefix, src)
+		if !bytes.HasPrefix(got, []byte("HEADER:")) {
+			t.Fatalf("prefix not preserved: %x", got[:7])
+		}
+		// Decompress the frame after the prefix.
+		var d Decoder
+		dec, err := d.AppendDecompress(nil, got[7:])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(dec, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("reuse", func(t *testing.T) {
+		e := NewEncoder()
+		src1 := []byte("first payload")
+		src2 := []byte("second payload, different content")
+
+		c1 := e.AppendCompress(nil, src1)
+		c2 := e.AppendCompress(nil, src2)
+
+		var d Decoder
+		got1, err := d.AppendDecompress(nil, c1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got2, err := d.AppendDecompress(nil, c2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got1, src1) || !bytes.Equal(got2, src2) {
+			t.Fatal("reuse mismatch")
+		}
+	})
+
+	t.Run("all_levels", func(t *testing.T) {
+		src := bytes.Repeat([]byte("AppendCompress test data across levels! "), 500)
+		for level := 1; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				e := NewEncoder()
+				if err := e.SetLevel(level); err != nil {
+					t.Fatal(err)
+				}
+				compressed := e.AppendCompress(nil, src)
+				r := NewReader(bytes.NewReader(compressed), nil)
+				defer func() { _ = r.Close() }()
+				got, err := io.ReadAll(r)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, src) {
+					t.Fatalf("AppendCompress mismatch at level %d", level)
+				}
+			})
+		}
+	})
+}
+
+func TestEncoder_AppendCompress_Concurrent(t *testing.T) {
+	t.Run("same_encoder", func(t *testing.T) {
+		src := bytes.Repeat([]byte("concurrent compress test data! "), 500)
+		e := NewEncoder()
+
+		const goroutines = 8
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		errs := make(chan error, goroutines)
+
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				compressed := e.AppendCompress(nil, src)
+				r := NewReader(bytes.NewReader(compressed), nil)
+				defer r.Close()
+				got, err := io.ReadAll(r)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(got, src) {
+					errs <- bytes.ErrTooLarge
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("all_levels", func(t *testing.T) {
+		src := bytes.Repeat([]byte("concurrent levels "), 500)
+
+		const goroutines = 10
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		errs := make(chan error, goroutines)
+
+		for i := range goroutines {
+			level := i % (BestCompression + 1)
+			go func() {
+				defer wg.Done()
+				le := NewEncoder()
+				_ = le.SetLevel(level)
+				compressed := le.AppendCompress(nil, src)
+				var d Decoder
+				got, err := d.AppendDecompress(nil, compressed)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(got, src) {
+					errs <- bytes.ErrTooLarge
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestEncoder_SetLevel(t *testing.T) {
+	t.Run("validation", func(t *testing.T) {
+		e := NewEncoder()
+		if err := e.SetLevel(DefaultCompression); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.SetLevel(NoCompression); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.SetLevel(BestSpeed); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.SetLevel(BestCompression); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.SetLevel(10); err == nil {
+			t.Fatal("expected error for invalid level")
+		}
+		if err := e.SetLevel(-2); err == nil {
+			t.Fatal("expected error for invalid level")
+		}
+	})
+
+	t.Run("switching", func(t *testing.T) {
+		src := bytes.Repeat([]byte("level switching test "), 200)
+		e := NewEncoder()
+		w := NewWriter(nil, e)
+		for level := 1; level <= BestCompression; level++ {
+			var buf bytes.Buffer
+			_ = e.SetLevel(level)
+			w.Reset(&buf)
+			_, _ = w.Write(src)
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 			got, err := io.ReadAll(r)
+			_ = r.Close()
 			if err != nil {
-				errs <- err
-				return
+				t.Fatalf("level %d: %v", level, err)
 			}
 			if !bytes.Equal(got, src) {
-				errs <- bytes.ErrTooLarge
+				t.Fatalf("level %d: mismatch", level)
 			}
-		}()
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Fatal(err)
-	}
+		}
+	})
+
+	t.Run("no_compression_raw", func(t *testing.T) {
+		src := bytes.Repeat([]byte("hello world! this is highly compressible data. "), 1000)
+		var buf bytes.Buffer
+		e := NewEncoder()
+		if err := e.SetLevel(NoCompression); err != nil {
+			t.Fatal(err)
+		}
+		w := NewWriter(&buf, e)
+		w.Reset(&buf)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if buf.Len() < len(src) {
+			t.Errorf("NoCompression reduced size: src=%d compressed=%d", len(src), buf.Len())
+		}
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer r.Close()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("roundtrip mismatch")
+		}
+
+		// Also test AppendCompress path.
+		buf.Reset()
+		e2 := NewEncoder()
+		if err := e2.SetLevel(NoCompression); err != nil {
+			t.Fatal(err)
+		}
+		compressed := e2.AppendCompress(nil, src)
+		if len(compressed) < len(src) {
+			t.Errorf("AppendCompress NoCompression reduced size: src=%d compressed=%d", len(src), len(compressed))
+		}
+		r2 := NewReader(bytes.NewReader(compressed), nil)
+		defer r2.Close()
+		got2, err := io.ReadAll(r2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got2, src) {
+			t.Fatal("AppendCompress roundtrip mismatch")
+		}
+	})
 }
 
-func TestSetWindowSize(t *testing.T) {
-	e := NewEncoder()
-	if err := e.SetWindowSize(MinWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.SetWindowSize(MaxWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.SetWindowSize(MinWindowSize - 1); err == nil {
-		t.Fatal("expected error for below min")
-	}
-	if err := e.SetWindowSize(MaxWindowSize + 1); err == nil {
-		t.Fatal("expected error for above max")
-	}
-	if err := e.SetWindowSize(0); err == nil {
-		t.Fatal("expected error for 0")
-	}
-	if err := e.SetWindowSize(-1); err == nil {
-		t.Fatal("expected error for negative")
-	}
+func TestEncoder_SetWindowSize(t *testing.T) {
+	t.Run("validation", func(t *testing.T) {
+		e := NewEncoder()
+		if err := e.SetWindowSize(MinWindowSize); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.SetWindowSize(MaxWindowSize); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.SetWindowSize(MinWindowSize - 1); err == nil {
+			t.Fatal("expected error for below min")
+		}
+		if err := e.SetWindowSize(MaxWindowSize + 1); err == nil {
+			t.Fatal("expected error for above max")
+		}
+		if err := e.SetWindowSize(0); err == nil {
+			t.Fatal("expected error for 0")
+		}
+		if err := e.SetWindowSize(-1); err == nil {
+			t.Fatal("expected error for negative")
+		}
+	})
+
+	t.Run("round_trip", func(t *testing.T) {
+		for _, wnd := range []int{1 << 16, 1 << 20, 8 << 20} {
+			// Keep data well under window size.
+			src := bytes.Repeat([]byte("wnd "), wnd/8)
+			e := NewEncoder()
+			_ = e.SetWindowSize(wnd)
+			frame := e.AppendCompress(nil, src)
+			var d Decoder
+			got, err := d.AppendDecompress(nil, frame)
+			if err != nil {
+				t.Fatalf("window %d: %v", wnd, err)
+			}
+			if !bytes.Equal(got, src) {
+				t.Fatalf("window %d: mismatch", wnd)
+			}
+		}
+	})
 }
 
-func TestSetCRCProducesChecksum(t *testing.T) {
+func TestEncoder_SetCRC(t *testing.T) {
 	src := bytes.Repeat([]byte("crc test "), 200)
 
 	withCRC := NewEncoder()
@@ -152,22 +463,38 @@ func TestSetCRCProducesChecksum(t *testing.T) {
 	}
 }
 
-func TestSetWindowSizeRoundTrip(t *testing.T) {
-	for _, wnd := range []int{1 << 16, 1 << 20, 8 << 20} {
-		// Keep data well under window size.
-		src := bytes.Repeat([]byte("wnd "), wnd/8)
-		e := NewEncoder()
-		_ = e.SetWindowSize(wnd)
-		frame := e.AppendCompress(nil, src)
-		var d Decoder
-		got, err := d.AppendDecompress(nil, frame)
+func TestEncoder_ZeroValue(t *testing.T) {
+	t.Run("append_compress", func(t *testing.T) {
+		src := bytes.Repeat([]byte("zero value writer "), 100)
+		var e Encoder
+		compressed := e.AppendCompress(nil, src)
+
+		r := NewReader(bytes.NewReader(compressed), nil)
+		defer r.Close()
+		got, err := io.ReadAll(r)
 		if err != nil {
-			t.Fatalf("window %d: %v", wnd, err)
+			t.Fatal(err)
 		}
 		if !bytes.Equal(got, src) {
-			t.Fatalf("window %d: mismatch", wnd)
+			t.Fatal("mismatch")
 		}
-	}
+	})
+
+	t.Run("config", func(t *testing.T) {
+		src := bytes.Repeat([]byte("zero config "), 100)
+		var e Encoder
+		e.SetCRC(false)
+		compressed := e.AppendCompress(nil, src)
+
+		var d Decoder
+		got, err := d.AppendDecompress(nil, compressed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
 }
 
 // These tests exercise the split configuration model: one Encoder/Decoder holds

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -72,10 +72,10 @@ func TestMatchLen(t *testing.T) {
 func TestEncoder_AppendCompress(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		src := bytes.Repeat([]byte("encode all test data! "), 500)
-		e := NewEncoder()
+		e := mustEncoder(t)
 		compressed := e.AppendCompress(nil, src)
 
-		r := NewReader(bytes.NewReader(compressed), nil)
+		r := mustReader(t, bytes.NewReader(compressed))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -87,7 +87,7 @@ func TestEncoder_AppendCompress(t *testing.T) {
 	})
 
 	t.Run("empty", func(t *testing.T) {
-		e := NewEncoder()
+		e := mustEncoder(t)
 		c1 := e.AppendCompress(nil, nil)
 		c2 := e.AppendCompress(nil, []byte{})
 		if len(c1) == 0 {
@@ -96,7 +96,7 @@ func TestEncoder_AppendCompress(t *testing.T) {
 		if !bytes.Equal(c1, c2) {
 			t.Fatal("nil and empty should produce identical frames")
 		}
-		r := NewReader(bytes.NewReader(c1), nil)
+		r := mustReader(t, bytes.NewReader(c1))
 		defer r.Close()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -108,8 +108,7 @@ func TestEncoder_AppendCompress(t *testing.T) {
 	})
 
 	t.Run("empty_crc", func(t *testing.T) {
-		e := NewEncoder()
-		e.SetCRC(true)
+		e := mustEncoder(t, WithEncoderCRC(true))
 		frame := e.AppendCompress(nil, nil)
 
 		var d Decoder
@@ -122,16 +121,14 @@ func TestEncoder_AppendCompress(t *testing.T) {
 		}
 
 		// Verify CRC is present: frame with CRC should be longer than without.
-		e.SetCRC(false)
-		noCRC := e.AppendCompress(nil, nil)
+		noCRC := mustEncoder(t, WithEncoderCRC(false)).AppendCompress(nil, nil)
 		if len(frame) <= len(noCRC) {
 			t.Fatalf("empty CRC frame (%d) should be longer than no-CRC (%d)", len(frame), len(noCRC))
 		}
 	})
 
 	t.Run("empty_no_crc", func(t *testing.T) {
-		e := NewEncoder()
-		e.SetCRC(false)
+		e := mustEncoder(t, WithEncoderCRC(false))
 		frame := e.AppendCompress(nil, nil)
 
 		var d Decoder
@@ -149,10 +146,10 @@ func TestEncoder_AppendCompress(t *testing.T) {
 		for i := range src {
 			src[i] = byte(i % 200)
 		}
-		e := NewEncoder()
+		e := mustEncoder(t)
 		compressed := e.AppendCompress(nil, src)
 
-		r := NewReader(bytes.NewReader(compressed), nil)
+		r := mustReader(t, bytes.NewReader(compressed))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -165,7 +162,7 @@ func TestEncoder_AppendCompress(t *testing.T) {
 
 	t.Run("pre_existing_dst", func(t *testing.T) {
 		src := []byte("data to compress")
-		e := NewEncoder()
+		e := mustEncoder(t)
 		prefix := []byte("HEADER:")
 		got := e.AppendCompress(prefix, src)
 		if !bytes.HasPrefix(got, []byte("HEADER:")) {
@@ -183,7 +180,7 @@ func TestEncoder_AppendCompress(t *testing.T) {
 	})
 
 	t.Run("reuse", func(t *testing.T) {
-		e := NewEncoder()
+		e := mustEncoder(t)
 		src1 := []byte("first payload")
 		src2 := []byte("second payload, different content")
 
@@ -208,12 +205,9 @@ func TestEncoder_AppendCompress(t *testing.T) {
 		src := bytes.Repeat([]byte("AppendCompress test data across levels! "), 500)
 		for level := 1; level <= BestCompression; level++ {
 			t.Run("", func(t *testing.T) {
-				e := NewEncoder()
-				if err := e.SetLevel(level); err != nil {
-					t.Fatal(err)
-				}
+				e := mustEncoder(t, WithEncoderLevel(level))
 				compressed := e.AppendCompress(nil, src)
-				r := NewReader(bytes.NewReader(compressed), nil)
+				r := mustReader(t, bytes.NewReader(compressed))
 				defer func() { _ = r.Close() }()
 				got, err := io.ReadAll(r)
 				if err != nil {
@@ -230,7 +224,7 @@ func TestEncoder_AppendCompress(t *testing.T) {
 func TestEncoder_AppendCompress_Concurrent(t *testing.T) {
 	t.Run("same_encoder", func(t *testing.T) {
 		src := bytes.Repeat([]byte("concurrent compress test data! "), 500)
-		e := NewEncoder()
+		e := mustEncoder(t)
 
 		const goroutines = 8
 		var wg sync.WaitGroup
@@ -241,7 +235,7 @@ func TestEncoder_AppendCompress_Concurrent(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				compressed := e.AppendCompress(nil, src)
-				r := NewReader(bytes.NewReader(compressed), nil)
+				r := mustReader(t, bytes.NewReader(compressed))
 				defer r.Close()
 				got, err := io.ReadAll(r)
 				if err != nil {
@@ -272,8 +266,7 @@ func TestEncoder_AppendCompress_Concurrent(t *testing.T) {
 			level := i % (BestCompression + 1)
 			go func() {
 				defer wg.Done()
-				le := NewEncoder()
-				_ = le.SetLevel(level)
+				le := mustEncoder(t, WithEncoderLevel(level))
 				compressed := le.AppendCompress(nil, src)
 				var d Decoder
 				got, err := d.AppendDecompress(nil, compressed)
@@ -306,7 +299,7 @@ func TestEncoder_AppendCompress_Concurrent(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				compressed := e.AppendCompress(nil, src)
-				got, err := NewDecoder().AppendDecompress(nil, compressed)
+				got, err := mustDecoder(t).AppendDecompress(nil, compressed)
 				if err != nil {
 					errs <- err
 					return
@@ -324,43 +317,31 @@ func TestEncoder_AppendCompress_Concurrent(t *testing.T) {
 	})
 }
 
-func TestEncoder_SetLevel(t *testing.T) {
+func TestWithEncoderLevel(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
-		e := NewEncoder()
-		if err := e.SetLevel(DefaultCompression); err != nil {
-			t.Fatal(err)
-		}
-		if err := e.SetLevel(NoCompression); err != nil {
-			t.Fatal(err)
-		}
-		if err := e.SetLevel(BestSpeed); err != nil {
-			t.Fatal(err)
-		}
-		if err := e.SetLevel(BestCompression); err != nil {
-			t.Fatal(err)
-		}
-		if err := e.SetLevel(10); err == nil {
+		mustEncoder(t, WithEncoderLevel(DefaultCompression))
+		mustEncoder(t, WithEncoderLevel(NoCompression))
+		mustEncoder(t, WithEncoderLevel(BestSpeed))
+		mustEncoder(t, WithEncoderLevel(BestCompression))
+		if _, err := NewEncoder(WithEncoderLevel(10)); err == nil {
 			t.Fatal("expected error for invalid level")
 		}
-		if err := e.SetLevel(-2); err == nil {
+		if _, err := NewEncoder(WithEncoderLevel(-2)); err == nil {
 			t.Fatal("expected error for invalid level")
 		}
 	})
 
 	t.Run("switching", func(t *testing.T) {
 		src := bytes.Repeat([]byte("level switching test "), 200)
-		e := NewEncoder()
-		w := NewWriter(nil, e)
 		for level := 1; level <= BestCompression; level++ {
 			var buf bytes.Buffer
-			_ = e.SetLevel(level)
-			w.Reset(&buf)
+			w := mustWriter(t, &buf, WithEncoderLevel(level))
 			_, _ = w.Write(src)
 			if err := w.Close(); err != nil {
 				t.Fatal(err)
 			}
 
-			r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+			r := mustReader(t, bytes.NewReader(buf.Bytes()))
 			got, err := io.ReadAll(r)
 			_ = r.Close()
 			if err != nil {
@@ -375,12 +356,7 @@ func TestEncoder_SetLevel(t *testing.T) {
 	t.Run("no_compression_raw", func(t *testing.T) {
 		src := bytes.Repeat([]byte("hello world! this is highly compressible data. "), 1000)
 		var buf bytes.Buffer
-		e := NewEncoder()
-		if err := e.SetLevel(NoCompression); err != nil {
-			t.Fatal(err)
-		}
-		w := NewWriter(&buf, e)
-		w.Reset(&buf)
+		w := mustWriter(t, &buf, WithEncoderLevel(NoCompression))
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
 		}
@@ -390,7 +366,7 @@ func TestEncoder_SetLevel(t *testing.T) {
 		if buf.Len() < len(src) {
 			t.Errorf("NoCompression reduced size: src=%d compressed=%d", len(src), buf.Len())
 		}
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer r.Close()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -402,15 +378,12 @@ func TestEncoder_SetLevel(t *testing.T) {
 
 		// Also test AppendCompress path.
 		buf.Reset()
-		e2 := NewEncoder()
-		if err := e2.SetLevel(NoCompression); err != nil {
-			t.Fatal(err)
-		}
+		e2 := mustEncoder(t, WithEncoderLevel(NoCompression))
 		compressed := e2.AppendCompress(nil, src)
 		if len(compressed) < len(src) {
 			t.Errorf("AppendCompress NoCompression reduced size: src=%d compressed=%d", len(src), len(compressed))
 		}
-		r2 := NewReader(bytes.NewReader(compressed), nil)
+		r2 := mustReader(t, bytes.NewReader(compressed))
 		defer r2.Close()
 		got2, err := io.ReadAll(r2)
 		if err != nil {
@@ -422,25 +395,20 @@ func TestEncoder_SetLevel(t *testing.T) {
 	})
 }
 
-func TestEncoder_SetWindowSize(t *testing.T) {
+func TestWithWindowSize(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
-		e := NewEncoder()
-		if err := e.SetWindowSize(MinWindowSize); err != nil {
-			t.Fatal(err)
-		}
-		if err := e.SetWindowSize(MaxWindowSize); err != nil {
-			t.Fatal(err)
-		}
-		if err := e.SetWindowSize(MinWindowSize - 1); err == nil {
+		mustEncoder(t, WithWindowSize(MinWindowSize))
+		mustEncoder(t, WithWindowSize(MaxWindowSize))
+		if _, err := NewEncoder(WithWindowSize(MinWindowSize - 1)); err == nil {
 			t.Fatal("expected error for below min")
 		}
-		if err := e.SetWindowSize(MaxWindowSize + 1); err == nil {
+		if _, err := NewEncoder(WithWindowSize(MaxWindowSize + 1)); err == nil {
 			t.Fatal("expected error for above max")
 		}
-		if err := e.SetWindowSize(0); err == nil {
+		if _, err := NewEncoder(WithWindowSize(0)); err == nil {
 			t.Fatal("expected error for 0")
 		}
-		if err := e.SetWindowSize(-1); err == nil {
+		if _, err := NewEncoder(WithWindowSize(-1)); err == nil {
 			t.Fatal("expected error for negative")
 		}
 	})
@@ -449,8 +417,7 @@ func TestEncoder_SetWindowSize(t *testing.T) {
 		for _, wnd := range []int{1 << 16, 1 << 20, 8 << 20} {
 			// Keep data well under window size.
 			src := bytes.Repeat([]byte("wnd "), wnd/8)
-			e := NewEncoder()
-			_ = e.SetWindowSize(wnd)
+			e := mustEncoder(t, WithWindowSize(wnd))
 			frame := e.AppendCompress(nil, src)
 			var d Decoder
 			got, err := d.AppendDecompress(nil, frame)
@@ -464,15 +431,13 @@ func TestEncoder_SetWindowSize(t *testing.T) {
 	})
 }
 
-func TestEncoder_SetCRC(t *testing.T) {
+func TestWithEncoderCRC(t *testing.T) {
 	src := bytes.Repeat([]byte("crc test "), 200)
 
-	withCRC := NewEncoder()
-	withCRC.SetCRC(true)
+	withCRC := mustEncoder(t, WithEncoderCRC(true))
 	crcFrame := withCRC.AppendCompress(nil, src)
 
-	noCRC := NewEncoder()
-	noCRC.SetCRC(false)
+	noCRC := mustEncoder(t, WithEncoderCRC(false))
 	noCRCFrame := noCRC.AppendCompress(nil, src)
 
 	// CRC adds 4 bytes (checksum) + 1 bit in FHD.
@@ -499,7 +464,7 @@ func TestEncoder_ZeroValue(t *testing.T) {
 		var e Encoder
 		compressed := e.AppendCompress(nil, src)
 
-		r := NewReader(bytes.NewReader(compressed), nil)
+		r := mustReader(t, bytes.NewReader(compressed))
 		defer r.Close()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -513,7 +478,6 @@ func TestEncoder_ZeroValue(t *testing.T) {
 	t.Run("config", func(t *testing.T) {
 		src := bytes.Repeat([]byte("zero config "), 100)
 		var e Encoder
-		e.SetCRC(false)
 		compressed := e.AppendCompress(nil, src)
 
 		var d Decoder
@@ -527,27 +491,23 @@ func TestEncoder_ZeroValue(t *testing.T) {
 	})
 }
 
-// These tests exercise the split configuration model: one Encoder/Decoder holds
-// configuration and can be reused across, or reconfigured between, streams.
+// These tests exercise the configuration model: each Writer takes its own
+// immutable options, and independent Writers keep separate streaming state.
 
 func TestEncoderReuseAcrossWriters(t *testing.T) {
-	e := NewEncoder()
-	if err := e.SetLevel(5); err != nil {
-		t.Fatal(err)
-	}
 	for _, src := range [][]byte{
 		bytes.Repeat([]byte("alpha "), 300),
 		bytes.Repeat([]byte("beta "), 300),
 	} {
 		var buf bytes.Buffer
-		w := NewWriter(&buf, e)
+		w := mustWriter(t, &buf, WithEncoderLevel(5))
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
 		}
 		if err := w.Close(); err != nil {
 			t.Fatal(err)
 		}
-		got, err := NewDecoder().AppendDecompress(nil, buf.Bytes())
+		got, err := mustDecoder(t).AppendDecompress(nil, buf.Bytes())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -557,13 +517,12 @@ func TestEncoderReuseAcrossWriters(t *testing.T) {
 	}
 }
 
-// TestEncoderSharedInterleavedWriters proves two Writers bound to one Encoder
-// keep independent streaming state.
+// TestEncoderSharedInterleavedWriters proves two independent Writers keep
+// independent streaming state.
 func TestEncoderSharedInterleavedWriters(t *testing.T) {
-	e := NewEncoder()
 	var b1, b2 bytes.Buffer
-	w1 := NewWriter(&b1, e)
-	w2 := NewWriter(&b2, e)
+	w1 := mustWriter(t, &b1)
+	w2 := mustWriter(t, &b2)
 	src1 := bytes.Repeat([]byte("first stream "), 500)
 	src2 := bytes.Repeat([]byte("second stream "), 500)
 
@@ -586,24 +545,21 @@ func TestEncoderSharedInterleavedWriters(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, err := NewDecoder().AppendDecompress(nil, b1.Bytes()); err != nil || !bytes.Equal(got, src1) {
+	if got, err := mustDecoder(t).AppendDecompress(nil, b1.Bytes()); err != nil || !bytes.Equal(got, src1) {
 		t.Fatalf("w1: err=%v match=%v", err, bytes.Equal(got, src1))
 	}
-	if got, err := NewDecoder().AppendDecompress(nil, b2.Bytes()); err != nil || !bytes.Equal(got, src2) {
+	if got, err := mustDecoder(t).AppendDecompress(nil, b2.Bytes()); err != nil || !bytes.Equal(got, src2) {
 		t.Fatalf("w2: err=%v match=%v", err, bytes.Equal(got, src2))
 	}
 }
 
-// TestEncoderReconfigureBetweenStreams changes settings on a bound Encoder
-// between streams and verifies the change takes effect on the next Reset.
+// TestEncoderReconfigureBetweenStreams verifies the CRC option is honored per
+// Writer: options are fixed at construction, so each variant uses a fresh Writer.
 func TestEncoderReconfigureBetweenStreams(t *testing.T) {
 	src := bytes.Repeat([]byte("reconfigure "), 200)
-	e := NewEncoder()
-	w := NewWriter(nil, e)
 
-	e.SetCRC(true)
 	var withCRC bytes.Buffer
-	w.Reset(&withCRC)
+	w := mustWriter(t, &withCRC, WithEncoderCRC(true))
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
 	}
@@ -611,10 +567,8 @@ func TestEncoderReconfigureBetweenStreams(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Reconfigure the SAME encoder, then reuse the SAME writer.
-	e.SetCRC(false)
 	var noCRC bytes.Buffer
-	w.Reset(&noCRC)
+	w = mustWriter(t, &noCRC, WithEncoderCRC(false))
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
 	}
@@ -627,7 +581,7 @@ func TestEncoderReconfigureBetweenStreams(t *testing.T) {
 		t.Fatalf("CRC toggle not applied: withCRC=%d noCRC=%d", withCRC.Len(), noCRC.Len())
 	}
 	for _, b := range []*bytes.Buffer{&withCRC, &noCRC} {
-		got, err := NewDecoder().AppendDecompress(nil, b.Bytes())
+		got, err := mustDecoder(t).AppendDecompress(nil, b.Bytes())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -637,24 +591,16 @@ func TestEncoderReconfigureBetweenStreams(t *testing.T) {
 	}
 }
 
-// TestEncoderReconfigureMidStreamDoesNotCorrupt verifies that reconfiguring the
-// bound Encoder mid-stream leaves the in-flight stream valid; the configuration
-// captured at Reset governs the current frame and the change applies at the next
-// Reset. (Toggling CRC mid-stream is unsupported; changing the level is safe.)
+// TestEncoderReconfigureMidStreamDoesNotCorrupt verifies that splitting a large
+// multi-block stream across multiple Write calls leaves the frame valid. (Options
+// are now immutable per Writer, so mid-stream reconfiguration is not possible.)
 func TestEncoderReconfigureMidStreamDoesNotCorrupt(t *testing.T) {
 	// Larger than one block so blocks are encoded during Write, not just at Close.
 	src := bytes.Repeat([]byte("mid stream reconfiguration test "), 10000)
-	e := NewEncoder()
-	if err := e.SetLevel(1); err != nil {
-		t.Fatal(err)
-	}
 	var buf bytes.Buffer
-	w := NewWriter(&buf, e)
+	w := mustWriter(t, &buf, WithEncoderLevel(1))
 
 	if _, err := w.Write(src[:len(src)/2]); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.SetLevel(9); err != nil { // mid-stream change
 		t.Fatal(err)
 	}
 	if _, err := w.Write(src[len(src)/2:]); err != nil {
@@ -664,9 +610,9 @@ func TestEncoderReconfigureMidStreamDoesNotCorrupt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := NewDecoder().AppendDecompress(nil, buf.Bytes())
+	got, err := mustDecoder(t).AppendDecompress(nil, buf.Bytes())
 	if err != nil {
-		t.Fatalf("mid-stream reconfig corrupted the frame: %v", err)
+		t.Fatalf("split-write stream corrupted the frame: %v", err)
 	}
 	if !bytes.Equal(got, src) {
 		t.Fatal("mismatch")

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -5,7 +5,10 @@
 package zstd
 
 import (
+	"bytes"
+	"io"
 	"math/rand/v2"
+	"sync"
 	"testing"
 )
 
@@ -63,5 +66,252 @@ func TestMatchLen(t *testing.T) {
 				t.Fatalf("matchLen: got %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAppendCompressConcurrent(t *testing.T) {
+	src := bytes.Repeat([]byte("concurrent compress test data! "), 500)
+	e := NewEncoder()
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			compressed := e.AppendCompress(nil, src)
+			r := NewReader(bytes.NewReader(compressed), nil)
+			defer r.Close()
+			got, err := io.ReadAll(r)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !bytes.Equal(got, src) {
+				errs <- bytes.ErrTooLarge
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}
+
+func TestSetWindowSize(t *testing.T) {
+	e := NewEncoder()
+	if err := e.SetWindowSize(MinWindowSize); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.SetWindowSize(MaxWindowSize); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.SetWindowSize(MinWindowSize - 1); err == nil {
+		t.Fatal("expected error for below min")
+	}
+	if err := e.SetWindowSize(MaxWindowSize + 1); err == nil {
+		t.Fatal("expected error for above max")
+	}
+	if err := e.SetWindowSize(0); err == nil {
+		t.Fatal("expected error for 0")
+	}
+	if err := e.SetWindowSize(-1); err == nil {
+		t.Fatal("expected error for negative")
+	}
+}
+
+func TestSetCRCProducesChecksum(t *testing.T) {
+	src := bytes.Repeat([]byte("crc test "), 200)
+
+	withCRC := NewEncoder()
+	withCRC.SetCRC(true)
+	crcFrame := withCRC.AppendCompress(nil, src)
+
+	noCRC := NewEncoder()
+	noCRC.SetCRC(false)
+	noCRCFrame := noCRC.AppendCompress(nil, src)
+
+	// CRC adds 4 bytes (checksum) + 1 bit in FHD.
+	if len(crcFrame) <= len(noCRCFrame) {
+		t.Fatalf("CRC frame (%d) should be larger than no-CRC frame (%d)", len(crcFrame), len(noCRCFrame))
+	}
+
+	// Both must decompress correctly.
+	var d Decoder
+	for _, frame := range [][]byte{crcFrame, noCRCFrame} {
+		got, err := d.AppendDecompress(nil, frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	}
+}
+
+func TestSetWindowSizeRoundTrip(t *testing.T) {
+	for _, wnd := range []int{1 << 16, 1 << 20, 8 << 20} {
+		// Keep data well under window size.
+		src := bytes.Repeat([]byte("wnd "), wnd/8)
+		e := NewEncoder()
+		_ = e.SetWindowSize(wnd)
+		frame := e.AppendCompress(nil, src)
+		var d Decoder
+		got, err := d.AppendDecompress(nil, frame)
+		if err != nil {
+			t.Fatalf("window %d: %v", wnd, err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatalf("window %d: mismatch", wnd)
+		}
+	}
+}
+
+// These tests exercise the split configuration model: one Encoder/Decoder holds
+// configuration and can be reused across, or reconfigured between, streams.
+
+func TestEncoderReuseAcrossWriters(t *testing.T) {
+	e := NewEncoder()
+	if err := e.SetLevel(5); err != nil {
+		t.Fatal(err)
+	}
+	for _, src := range [][]byte{
+		bytes.Repeat([]byte("alpha "), 300),
+		bytes.Repeat([]byte("beta "), 300),
+	} {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, e)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		got, err := NewDecoder().AppendDecompress(nil, buf.Bytes())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	}
+}
+
+// TestEncoderSharedInterleavedWriters proves two Writers bound to one Encoder
+// keep independent streaming state.
+func TestEncoderSharedInterleavedWriters(t *testing.T) {
+	e := NewEncoder()
+	var b1, b2 bytes.Buffer
+	w1 := NewWriter(&b1, e)
+	w2 := NewWriter(&b2, e)
+	src1 := bytes.Repeat([]byte("first stream "), 500)
+	src2 := bytes.Repeat([]byte("second stream "), 500)
+
+	if _, err := w1.Write(src1[:len(src1)/2]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w2.Write(src2[:len(src2)/2]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w1.Write(src1[len(src1)/2:]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w2.Write(src2[len(src2)/2:]); err != nil {
+		t.Fatal(err)
+	}
+	if err := w1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, err := NewDecoder().AppendDecompress(nil, b1.Bytes()); err != nil || !bytes.Equal(got, src1) {
+		t.Fatalf("w1: err=%v match=%v", err, bytes.Equal(got, src1))
+	}
+	if got, err := NewDecoder().AppendDecompress(nil, b2.Bytes()); err != nil || !bytes.Equal(got, src2) {
+		t.Fatalf("w2: err=%v match=%v", err, bytes.Equal(got, src2))
+	}
+}
+
+// TestEncoderReconfigureBetweenStreams changes settings on a bound Encoder
+// between streams and verifies the change takes effect on the next Reset.
+func TestEncoderReconfigureBetweenStreams(t *testing.T) {
+	src := bytes.Repeat([]byte("reconfigure "), 200)
+	e := NewEncoder()
+	w := NewWriter(nil, e)
+
+	e.SetCRC(true)
+	var withCRC bytes.Buffer
+	w.Reset(&withCRC)
+	if _, err := w.Write(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reconfigure the SAME encoder, then reuse the SAME writer.
+	e.SetCRC(false)
+	var noCRC bytes.Buffer
+	w.Reset(&noCRC)
+	if _, err := w.Write(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The change must be observable: the checksummed frame is 4 bytes longer.
+	if withCRC.Len() != noCRC.Len()+4 {
+		t.Fatalf("CRC toggle not applied: withCRC=%d noCRC=%d", withCRC.Len(), noCRC.Len())
+	}
+	for _, b := range []*bytes.Buffer{&withCRC, &noCRC} {
+		got, err := NewDecoder().AppendDecompress(nil, b.Bytes())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	}
+}
+
+// TestEncoderReconfigureMidStreamDoesNotCorrupt verifies that reconfiguring the
+// bound Encoder mid-stream leaves the in-flight stream valid; the configuration
+// captured at Reset governs the current frame and the change applies at the next
+// Reset. (Toggling CRC mid-stream is unsupported; changing the level is safe.)
+func TestEncoderReconfigureMidStreamDoesNotCorrupt(t *testing.T) {
+	// Larger than one block so blocks are encoded during Write, not just at Close.
+	src := bytes.Repeat([]byte("mid stream reconfiguration test "), 10000)
+	e := NewEncoder()
+	if err := e.SetLevel(1); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	w := NewWriter(&buf, e)
+
+	if _, err := w.Write(src[:len(src)/2]); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.SetLevel(9); err != nil { // mid-stream change
+		t.Fatal(err)
+	}
+	if _, err := w.Write(src[len(src)/2:]); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := NewDecoder().AppendDecompress(nil, buf.Bytes())
+	if err != nil {
+		t.Fatalf("mid-stream reconfig corrupted the frame: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch")
 	}
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -458,6 +458,33 @@ func TestWithEncoderCRC(t *testing.T) {
 	}
 }
 
+func TestWithContentSize(t *testing.T) {
+	t.Run("append_compress_ignores", func(t *testing.T) {
+		src := bytes.Repeat([]byte("append compress ignores content size. "), 50)
+
+		plain := mustEncoder(t).AppendCompress(nil, src)
+		// A bogus content size must not affect one-shot output.
+		withCS := mustEncoder(t, WithContentSize(999999)).AppendCompress(nil, src)
+		if !bytes.Equal(plain, withCS) {
+			t.Fatal("AppendCompress output changed by WithContentSize")
+		}
+
+		got, err := mustDecoder(t).AppendDecompress(nil, withCS)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("negative_is_error", func(t *testing.T) {
+		if _, err := NewEncoder(WithContentSize(-1)); err == nil {
+			t.Fatal("expected error for negative content size")
+		}
+	})
+}
+
 func TestEncoder_ZeroValue(t *testing.T) {
 	t.Run("append_compress", func(t *testing.T) {
 		src := bytes.Repeat([]byte("zero value writer "), 100)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -292,6 +292,36 @@ func TestEncoder_AppendCompress_Concurrent(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("zero_value", func(t *testing.T) {
+		src := bytes.Repeat([]byte("zero value concurrent "), 200)
+		var e Encoder
+
+		const goroutines = 8
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		errs := make(chan error, goroutines)
+
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				compressed := e.AppendCompress(nil, src)
+				got, err := NewDecoder().AppendDecompress(nil, compressed)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !bytes.Equal(got, src) {
+					errs <- bytes.ErrTooLarge
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestEncoder_SetLevel(t *testing.T) {

--- a/examples_test.go
+++ b/examples_test.go
@@ -13,16 +13,21 @@ import (
 
 func Example_writerReader() {
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
-	_, err := w.Write([]byte("Hello, zstd!"))
+	w, err := zstd.NewWriter(&buf)
 	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := w.Write([]byte("Hello, zstd!")); err != nil {
 		log.Fatal(err)
 	}
 	if err := w.Close(); err != nil {
 		log.Fatal(err)
 	}
 
-	r := zstd.NewReader(&buf, nil)
+	r, err := zstd.NewReader(&buf)
+	if err != nil {
+		log.Fatal(err)
+	}
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
 	}
@@ -34,10 +39,16 @@ func Example_writerReader() {
 func ExampleEncoder_AppendCompress() {
 	src := []byte("One-shot compression is the simplest API.")
 
-	e := zstd.NewEncoder()
+	e, err := zstd.NewEncoder()
+	if err != nil {
+		log.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, src)
 
-	d := zstd.NewDecoder()
+	d, err := zstd.NewDecoder()
+	if err != nil {
+		log.Fatal(err)
+	}
 	decompressed, err := d.AppendDecompress(nil, compressed)
 	if err != nil {
 		log.Fatal(err)
@@ -50,10 +61,16 @@ func ExampleEncoder_AppendCompress() {
 func ExampleDecoder_AppendDecompress() {
 	src := []byte("appended to existing buffer")
 
-	e := zstd.NewEncoder()
+	e, err := zstd.NewEncoder()
+	if err != nil {
+		log.Fatal(err)
+	}
 	compressed := e.AppendCompress(nil, src)
 
-	d := zstd.NewDecoder()
+	d, err := zstd.NewDecoder()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	prefix := []byte("data: ")
 	result, err := d.AppendDecompress(prefix, compressed)
@@ -65,12 +82,12 @@ func ExampleDecoder_AppendDecompress() {
 	// data: appended to existing buffer
 }
 
-func ExampleEncoder_SetLevel() {
+func ExampleWithEncoderLevel() {
 	data := []byte(strings.Repeat("the quick brown fox jumps over the lazy dog. ", 100))
 
 	compress := func(level int) []byte {
-		e := zstd.NewEncoder()
-		if err := e.SetLevel(level); err != nil {
+		e, err := zstd.NewEncoder(zstd.WithEncoderLevel(level))
+		if err != nil {
 			log.Fatal(err)
 		}
 		return e.AppendCompress(nil, data)
@@ -79,7 +96,10 @@ func ExampleEncoder_SetLevel() {
 	fast := compress(zstd.BestSpeed)
 	best := compress(zstd.BestCompression)
 
-	d := zstd.NewDecoder()
+	d, err := zstd.NewDecoder()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	got, err := d.AppendDecompress(nil, fast)
 	if err != nil || string(got) != string(data) {
@@ -108,8 +128,14 @@ func Example_reset() {
 	}
 
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
-	r := zstd.NewReader(&buf, nil)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		log.Fatal(err)
+	}
+	r, err := zstd.NewReader(&buf)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	for _, p := range proverbs {
 		buf.Reset()
@@ -140,7 +166,10 @@ func Example_reset() {
 
 func ExampleWriter_Flush() {
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if _, err := w.Write([]byte("first part.")); err != nil {
 		log.Fatal(err)
@@ -156,7 +185,10 @@ func ExampleWriter_Flush() {
 		log.Fatal(err)
 	}
 
-	r := zstd.NewReader(&buf, nil)
+	r, err := zstd.NewReader(&buf)
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer r.Close()
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
@@ -168,7 +200,10 @@ func ExampleWriter_Flush() {
 func ExampleWriter_ReadFrom() {
 	input := strings.NewReader("ReadFrom compresses data from an io.Reader efficiently.")
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf, nil)
+	w, err := zstd.NewWriter(&buf)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if _, err := w.ReadFrom(input); err != nil {
 		log.Fatal(err)
@@ -177,7 +212,10 @@ func ExampleWriter_ReadFrom() {
 		log.Fatal(err)
 	}
 
-	r := zstd.NewReader(&buf, nil)
+	r, err := zstd.NewReader(&buf)
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer r.Close()
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
@@ -186,14 +224,18 @@ func ExampleWriter_ReadFrom() {
 	// ReadFrom compresses data from an io.Reader efficiently.
 }
 
-func ExampleEncoder_SetRawDict() {
+func ExampleWithEncoderRawDict() {
 	dict := []byte("the quick brown fox jumps over the lazy dog")
 	data := []byte("the quick brown fox leaps over the sleepy dog")
 
 	compressWithDict := func(d []byte) []byte {
-		enc := zstd.NewEncoder()
+		var opts []zstd.EncoderOption
 		if d != nil {
-			enc.SetRawDict(d)
+			opts = append(opts, zstd.WithEncoderRawDict(d))
+		}
+		enc, err := zstd.NewEncoder(opts...)
+		if err != nil {
+			log.Fatal(err)
 		}
 		return enc.AppendCompress(nil, data)
 	}
@@ -201,7 +243,10 @@ func ExampleEncoder_SetRawDict() {
 	without := compressWithDict(nil)
 	with := compressWithDict(dict)
 
-	dec := zstd.NewDecoder()
+	dec, err := zstd.NewDecoder()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	got, err := dec.AppendDecompress(nil, without)
 	if err != nil || string(got) != string(data) {
@@ -209,7 +254,10 @@ func ExampleEncoder_SetRawDict() {
 	}
 	fmt.Println("without dict: OK")
 
-	dec.SetRawDict(dict)
+	dec, err = zstd.NewDecoder(zstd.WithDecoderRawDict(dict))
+	if err != nil {
+		log.Fatal(err)
+	}
 	got, err = dec.AppendDecompress(nil, with)
 	if err != nil || string(got) != string(data) {
 		log.Fatal("with dict mismatch")

--- a/examples_test.go
+++ b/examples_test.go
@@ -13,7 +13,7 @@ import (
 
 func Example_writerReader() {
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
+	w := zstd.NewWriter(&buf, nil)
 	_, err := w.Write([]byte("Hello, zstd!"))
 	if err != nil {
 		log.Fatal(err)
@@ -22,7 +22,7 @@ func Example_writerReader() {
 		log.Fatal(err)
 	}
 
-	r := zstd.NewReader(&buf)
+	r := zstd.NewReader(&buf, nil)
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
 	}
@@ -31,15 +31,14 @@ func Example_writerReader() {
 	// Hello, zstd!
 }
 
-func ExampleWriter_AppendCompress() {
+func ExampleEncoder_AppendCompress() {
 	src := []byte("One-shot compression is the simplest API.")
 
-	w := zstd.NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	r := zstd.NewReader(bytes.NewReader(nil))
-	defer r.Close()
-	decompressed, err := r.AppendDecompress(nil, compressed)
+	d := zstd.NewDecoder()
+	decompressed, err := d.AppendDecompress(nil, compressed)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -48,17 +47,16 @@ func ExampleWriter_AppendCompress() {
 	// One-shot compression is the simplest API.
 }
 
-func ExampleReader_AppendDecompress() {
+func ExampleDecoder_AppendDecompress() {
 	src := []byte("appended to existing buffer")
 
-	w := zstd.NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := zstd.NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	r := zstd.NewReader(bytes.NewReader(nil))
-	defer r.Close()
+	d := zstd.NewDecoder()
 
 	prefix := []byte("data: ")
-	result, err := r.AppendDecompress(prefix, compressed)
+	result, err := d.AppendDecompress(prefix, compressed)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -67,31 +65,30 @@ func ExampleReader_AppendDecompress() {
 	// data: appended to existing buffer
 }
 
-func ExampleWriter_SetLevel() {
+func ExampleEncoder_SetLevel() {
 	data := []byte(strings.Repeat("the quick brown fox jumps over the lazy dog. ", 100))
 
 	compress := func(level int) []byte {
-		w := zstd.NewWriter(nil)
-		if err := w.SetLevel(level); err != nil {
+		e := zstd.NewEncoder()
+		if err := e.SetLevel(level); err != nil {
 			log.Fatal(err)
 		}
-		return w.AppendCompress(nil, data)
+		return e.AppendCompress(nil, data)
 	}
 
 	fast := compress(zstd.BestSpeed)
 	best := compress(zstd.BestCompression)
 
-	r := zstd.NewReader(bytes.NewReader(nil))
-	defer r.Close()
+	d := zstd.NewDecoder()
 
-	dec, err := r.AppendDecompress(nil, fast)
-	if err != nil || string(dec) != string(data) {
+	got, err := d.AppendDecompress(nil, fast)
+	if err != nil || string(got) != string(data) {
 		log.Fatal("BestSpeed mismatch")
 	}
 	fmt.Println("BestSpeed: OK")
 
-	dec, err = r.AppendDecompress(nil, best)
-	if err != nil || string(dec) != string(data) {
+	got, err = d.AppendDecompress(nil, best)
+	if err != nil || string(got) != string(data) {
 		log.Fatal("BestCompression mismatch")
 	}
 	fmt.Println("BestCompression: OK")
@@ -111,8 +108,8 @@ func Example_reset() {
 	}
 
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
-	r := zstd.NewReader(&buf)
+	w := zstd.NewWriter(&buf, nil)
+	r := zstd.NewReader(&buf, nil)
 
 	for _, p := range proverbs {
 		buf.Reset()
@@ -143,7 +140,7 @@ func Example_reset() {
 
 func ExampleWriter_Flush() {
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
+	w := zstd.NewWriter(&buf, nil)
 
 	if _, err := w.Write([]byte("first part.")); err != nil {
 		log.Fatal(err)
@@ -159,7 +156,7 @@ func ExampleWriter_Flush() {
 		log.Fatal(err)
 	}
 
-	r := zstd.NewReader(&buf)
+	r := zstd.NewReader(&buf, nil)
 	defer r.Close()
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
@@ -171,7 +168,7 @@ func ExampleWriter_Flush() {
 func ExampleWriter_ReadFrom() {
 	input := strings.NewReader("ReadFrom compresses data from an io.Reader efficiently.")
 	var buf bytes.Buffer
-	w := zstd.NewWriter(&buf)
+	w := zstd.NewWriter(&buf, nil)
 
 	if _, err := w.ReadFrom(input); err != nil {
 		log.Fatal(err)
@@ -180,7 +177,7 @@ func ExampleWriter_ReadFrom() {
 		log.Fatal(err)
 	}
 
-	r := zstd.NewReader(&buf)
+	r := zstd.NewReader(&buf, nil)
 	defer r.Close()
 	if _, err := io.Copy(os.Stdout, r); err != nil {
 		log.Fatal(err)
@@ -189,33 +186,32 @@ func ExampleWriter_ReadFrom() {
 	// ReadFrom compresses data from an io.Reader efficiently.
 }
 
-func ExampleWriter_SetRawDict() {
+func ExampleEncoder_SetRawDict() {
 	dict := []byte("the quick brown fox jumps over the lazy dog")
 	data := []byte("the quick brown fox leaps over the sleepy dog")
 
 	compressWithDict := func(d []byte) []byte {
-		w := zstd.NewWriter(nil)
+		enc := zstd.NewEncoder()
 		if d != nil {
-			w.SetRawDict(d)
+			enc.SetRawDict(d)
 		}
-		return w.AppendCompress(nil, data)
+		return enc.AppendCompress(nil, data)
 	}
 
 	without := compressWithDict(nil)
 	with := compressWithDict(dict)
 
-	r := zstd.NewReader(bytes.NewReader(nil))
-	defer r.Close()
+	dec := zstd.NewDecoder()
 
-	dec, err := r.AppendDecompress(nil, without)
-	if err != nil || string(dec) != string(data) {
+	got, err := dec.AppendDecompress(nil, without)
+	if err != nil || string(got) != string(data) {
 		log.Fatal("without dict mismatch")
 	}
 	fmt.Println("without dict: OK")
 
-	r.SetRawDict(dict)
-	dec, err = r.AppendDecompress(nil, with)
-	if err != nil || string(dec) != string(data) {
+	dec.SetRawDict(dict)
+	got, err = dec.AppendDecompress(nil, with)
+	if err != nil || string(got) != string(data) {
 		log.Fatal("with dict mismatch")
 	}
 	fmt.Println("with dict: OK")

--- a/framedec.go
+++ b/framedec.go
@@ -7,14 +7,19 @@ package zstd
 import (
 	"encoding/binary"
 	"io"
+	"sync"
 
 	"github.com/klauspost/stdgozstd/internal/xxhash"
 )
 
+// frameDecPool holds frame decoders for reuse.
+var frameDecPool sync.Pool
+
 // decoderOptions holds configuration for the frame decoder.
 type decoderOptions struct {
-	maxWindowSize int
-	lowMem        bool
+	maxWindowSize  int
+	maxDecodedSize int64 // 0 = unlimited
+	lowMem         bool
 }
 
 // Limits for the decoder window size, as defined by the zstd specification.
@@ -168,6 +173,12 @@ func (d *frameDec) reset(br byteBuffer) error {
 		}
 	}
 
+	// Reject a frame whose declared content size alone exceeds the limit,
+	// before allocating buffers or decoding any block.
+	if d.o.maxDecodedSize > 0 && d.FrameContentSize != fcsUnknown && d.FrameContentSize > uint64(d.o.maxDecodedSize) {
+		return &ErrDecodedSizeExceeded{Allowed: d.o.maxDecodedSize, Produced: int64(d.FrameContentSize)}
+	}
+
 	d.HasCheckSum = fhd&(1<<2) != 0
 	if d.HasCheckSum {
 		if d.crc == nil {
@@ -226,7 +237,11 @@ const maxDirectDecodeSize = 1 << 20 // 1 MiB
 
 // runDecoder decodes all blocks into dst (used for DecodeAll-style calls).
 // Falls back to streaming if content exceeds maxDirectDecodeSize.
-func (d *frameDec) runDecoder(dst []byte, dec *blockDec) ([]byte, error) {
+//
+// maxTotal (when > 0) caps the cumulative output measured from dstStart, the
+// length of dst at the start of the enclosing decode call; this bounds output
+// across concatenated frames even when a frame's content size is absent or lies.
+func (d *frameDec) runDecoder(dst []byte, dec *blockDec, maxTotal int64, dstStart int) ([]byte, error) {
 	saved := d.history.b
 
 	d.history.b = dst
@@ -250,6 +265,10 @@ func (d *frameDec) runDecoder(dst []byte, dec *blockDec) ([]byte, error) {
 		}
 		err = dec.decodeBuf(&d.history)
 		if err != nil {
+			break
+		}
+		if maxTotal > 0 && int64(len(d.history.b)-dstStart) > maxTotal {
+			err = &ErrDecodedSizeExceeded{Allowed: maxTotal, Produced: int64(len(d.history.b) - dstStart)}
 			break
 		}
 		if dec.Last {

--- a/framedec.go
+++ b/framedec.go
@@ -7,6 +7,7 @@ package zstd
 import (
 	"encoding/binary"
 	"io"
+	"math"
 	"sync"
 
 	"github.com/klauspost/stdgozstd/internal/xxhash"
@@ -176,7 +177,8 @@ func (d *frameDec) reset(br byteBuffer) error {
 	// Reject a frame whose declared content size alone exceeds the limit,
 	// before allocating buffers or decoding any block.
 	if d.o.maxDecodedSize > 0 && d.FrameContentSize != fcsUnknown && d.FrameContentSize > uint64(d.o.maxDecodedSize) {
-		return &ErrDecodedSizeExceeded{Allowed: d.o.maxDecodedSize, Produced: int64(d.FrameContentSize)}
+		// Clamp to avoid int64 overflow when FrameContentSize exceeds MaxInt64.
+		return &ErrDecodedSizeExceeded{Allowed: d.o.maxDecodedSize, Produced: int64(min(d.FrameContentSize, math.MaxInt64))}
 	}
 
 	d.HasCheckSum = fhd&(1<<2) != 0

--- a/framedec.go
+++ b/framedec.go
@@ -60,6 +60,24 @@ func newFrameDec(o decoderOptions) *frameDec {
 	return &frameDec{o: o}
 }
 
+// applyFrameDict wires the frame's dictionary from dicts using the frame's
+// DictionaryID: a nonzero ID must be present (else [ErrUnknownDictionary]),
+// while ID 0 falls back to a raw dictionary used only for match references.
+func applyFrameDict(frame *frameDec, dicts map[uint32]*dict) error {
+	if frame.DictionaryID != 0 {
+		d, ok := dicts[frame.DictionaryID]
+		if !ok {
+			return ErrUnknownDictionary
+		}
+		frame.history.setDict(d)
+	} else if d, ok := dicts[0]; ok {
+		// Raw dict (ID 0): only use content for match references.
+		frame.history.dict = d
+		frame.history.decoders.dict = d.content
+	}
+	return nil
+}
+
 // reset parses the frame header from br, preparing for block decoding.
 func (d *frameDec) reset(br byteBuffer) error {
 	d.HasCheckSum = false

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -16,19 +16,19 @@ func FuzzRoundTrip(f *testing.F) {
 	f.Add([]byte{0})
 	f.Add(bytes.Repeat([]byte("abcdef"), 1000))
 	f.Add(make([]byte, 65536))
-	w := NewWriter(nil)
-	r := NewReader(bytes.NewReader(nil))
+	e := NewEncoder()
+	d := NewDecoder()
+	r := NewReader(nil, d)
 	var compressed []byte
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		w.Reset(nil)
 		if len(data) > 0 {
-			_ = w.SetLevel(int(data[0] % BestCompression))
+			_ = e.SetLevel(int(data[0] % BestCompression))
 		}
 		// We disable CRC for the truncation tests to be more effective.
 		// Otherwise CRC will always be missing.
-		w.SetCRC(false)
-		compressed = w.AppendCompress(compressed[:0], data)
+		e.SetCRC(false)
+		compressed = e.AppendCompress(compressed[:0], data)
 
 		_ = r.Reset(bytes.NewReader(compressed))
 		got, err := io.ReadAll(r)
@@ -39,7 +39,7 @@ func FuzzRoundTrip(f *testing.F) {
 			t.Fatalf("round-trip mismatch: got %d bytes, want %d", len(got), len(data))
 		}
 		// Test Byte interface.
-		got, err = r.AppendDecompress(got[:0], compressed)
+		got, err = d.AppendDecompress(got[:0], compressed)
 		if err != nil {
 			t.Fatalf("AppendDecompress: %v", err)
 		}
@@ -66,7 +66,7 @@ func FuzzRoundTrip(f *testing.F) {
 		if len(compressed) < 2 {
 			return
 		}
-		_, err = r.AppendDecompress(got[:0], compressed[:len(compressed)/2])
+		_, err = d.AppendDecompress(got[:0], compressed[:len(compressed)/2])
 		if err == nil {
 			t.Fatal("expected error from AppendDecompress due to truncated input")
 		}
@@ -81,17 +81,18 @@ func FuzzRoundTrip(f *testing.F) {
 
 func FuzzNewReader(f *testing.F) {
 	// Seed with valid compressed data.
-	w := NewWriter(nil)
-	f.Add(w.AppendCompress(nil, []byte("test")))
-	f.Add(w.AppendCompress(nil, []byte("testtesttesttesttesttesttesttest")))
-	f.Add(w.AppendCompress(nil, bytes.Repeat([]byte{0}, 100000)))
-	f.Add(w.AppendCompress(nil, []byte{}))
+	e := NewEncoder()
+	f.Add(e.AppendCompress(nil, []byte("test")))
+	f.Add(e.AppendCompress(nil, []byte("testtesttesttesttesttesttesttest")))
+	f.Add(e.AppendCompress(nil, bytes.Repeat([]byte{0}, 100000)))
+	f.Add(e.AppendCompress(nil, []byte{}))
 	f.Add([]byte{0x28, 0xb5, 0x2f, 0xfd}) // just magic
-	r := NewReader(nil)
+	d := NewDecoder()
 	// Cap window to prevent OOM on crafted frames.
-	if err := r.SetMaxWindowSize(1 << 20); err != nil {
+	if err := d.SetMaxWindowSize(1 << 20); err != nil {
 		f.Fatal(err)
 	}
+	r := NewReader(nil, d)
 	defer r.Close()
 	var dst []byte
 
@@ -102,7 +103,7 @@ func FuzzNewReader(f *testing.F) {
 		}
 		n, _ := io.Copy(io.Discard, io.Reader(r))
 		if n < 1<<20 {
-			dst, _ = r.AppendDecompress(dst[:0], data)
+			dst, _ = d.AppendDecompress(dst[:0], data)
 		}
 		err = r.Reset(bytes.NewReader(data))
 		if err != nil {
@@ -120,8 +121,10 @@ func FuzzStreamRoundTrip(f *testing.F) {
 	f.Add([]byte{0, 0}, []byte{})
 	f.Add([]byte{9, 5}, bytes.Repeat([]byte("abcdef"), 1000))
 	f.Add([]byte{0x85, 0xff}, make([]byte, 65536))
-	w := NewWriter(nil)
-	r := NewReader(bytes.NewReader(nil))
+	e := NewEncoder()
+	w := NewWriter(nil, e)
+	d := NewDecoder()
+	r := NewReader(nil, d)
 
 	f.Fuzz(func(t *testing.T, cfg, data []byte) {
 		if len(cfg) != 2 {
@@ -138,9 +141,9 @@ func FuzzStreamRoundTrip(f *testing.F) {
 		}
 
 		var buf bytes.Buffer
-		_ = w.SetLevel(level)
-		w.SetCRC(crc)
-		w.SetLowMemory(lowMem)
+		_ = e.SetLevel(level)
+		e.SetCRC(crc)
+		e.SetLowMemory(lowMem)
 		w.Reset(&buf)
 		_, _ = w.Write(data[:split])
 		_ = w.Flush()
@@ -178,7 +181,7 @@ func FuzzStreamRoundTrip(f *testing.F) {
 		if len(compressed) < 2 {
 			return
 		}
-		_, err = r.AppendDecompress(got[:0], compressed[:len(compressed)/2])
+		_, err = d.AppendDecompress(got[:0], compressed[:len(compressed)/2])
 		if err == nil {
 			t.Fatal("expected error from AppendDecompress due to truncated input")
 		}
@@ -195,8 +198,8 @@ func FuzzDictRoundTrip(f *testing.F) {
 	f.Add([]byte{3, 10}, bytes.Repeat([]byte("the quick brown fox "), 50))
 	f.Add([]byte{0, 0}, []byte("small"))
 	f.Add([]byte{0, 0}, []byte("smallsmallsmallsmallsmall"))
-	w := NewWriter(nil)
-	r := NewReader(bytes.NewReader(nil))
+	e := NewEncoder()
+	d := NewDecoder()
 
 	f.Fuzz(func(t *testing.T, cfg, data []byte) {
 		if len(cfg) < 2 || len(data) < 2 {
@@ -211,14 +214,13 @@ func FuzzDictRoundTrip(f *testing.F) {
 		dictPart := data[:dictSplit]
 		dataPart := data[dictSplit:]
 
-		_ = w.SetLevel(level)
-		w.SetCRC(crc)
-		w.SetRawDict(dictPart)
-		compressed := w.AppendCompress(nil, dataPart)
+		_ = e.SetLevel(level)
+		e.SetCRC(crc)
+		e.SetRawDict(dictPart)
+		compressed := e.AppendCompress(nil, dataPart)
 
-		_ = r.Reset(bytes.NewReader(nil))
-		r.SetRawDict(dictPart)
-		got, err := r.AppendDecompress(nil, compressed)
+		d.SetRawDict(dictPart)
+		got, err := d.AppendDecompress(nil, compressed)
 		if err != nil {
 			t.Fatalf("decode: %v", err)
 		}
@@ -265,19 +267,20 @@ func FuzzReaderReset(f *testing.F) {
 	f.Add(byte(3), []byte("hello reset world"))
 	f.Add(byte(0), []byte{})
 	f.Add(byte(9), bytes.Repeat([]byte("reset"), 500))
-	w := NewWriter(nil)
-	r := NewReader(bytes.NewReader(nil))
+	e := NewEncoder()
+	d := NewDecoder()
+	r := NewReader(nil, d)
 	var buf bytes.Buffer
 
 	f.Fuzz(func(t *testing.T, levelByte byte, data []byte) {
 		level := int(levelByte) % (BestCompression + 1)
 
-		_ = w.SetLevel(level)
-		compressed1 := w.AppendCompress(nil, data)
+		_ = e.SetLevel(level)
+		compressed1 := e.AppendCompress(nil, data)
 
 		level2 := (level + 1) % (BestCompression + 1)
-		_ = w.SetLevel(level2)
-		compressed2 := w.AppendCompress(nil, data)
+		_ = e.SetLevel(level2)
+		compressed2 := e.AppendCompress(nil, data)
 
 		_ = r.Reset(bytes.NewReader(compressed1))
 		got, err := io.ReadAll(r)
@@ -310,8 +313,7 @@ func FuzzReaderReset(f *testing.F) {
 			t.Fatal("WriteTo read mismatch")
 		}
 
-		_ = r.Reset(bytes.NewReader(nil))
-		got, err = r.AppendDecompress(nil, compressed1)
+		got, err = d.AppendDecompress(nil, compressed1)
 		if err != nil {
 			t.Fatalf("DecodeBytes after Reset: %v", err)
 		}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -25,7 +25,7 @@ func FuzzRoundTrip(f *testing.F) {
 		// Otherwise CRC will always be missing.
 		level := 3
 		if len(data) > 0 {
-			level = int(data[0] % BestCompression)
+			level = int(data[0] % (BestCompression + 1))
 		}
 		e := mustEncoder(t, WithEncoderLevel(level), WithEncoderCRC(false))
 		compressed = e.AppendCompress(compressed[:0], data)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -16,18 +16,18 @@ func FuzzRoundTrip(f *testing.F) {
 	f.Add([]byte{0})
 	f.Add(bytes.Repeat([]byte("abcdef"), 1000))
 	f.Add(make([]byte, 65536))
-	e := NewEncoder()
-	d := NewDecoder()
-	r := NewReader(nil, d)
+	d := mustDecoder(f)
+	r := mustReader(f, nil)
 	var compressed []byte
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		if len(data) > 0 {
-			_ = e.SetLevel(int(data[0] % BestCompression))
-		}
 		// We disable CRC for the truncation tests to be more effective.
 		// Otherwise CRC will always be missing.
-		e.SetCRC(false)
+		level := 3
+		if len(data) > 0 {
+			level = int(data[0] % BestCompression)
+		}
+		e := mustEncoder(t, WithEncoderLevel(level), WithEncoderCRC(false))
 		compressed = e.AppendCompress(compressed[:0], data)
 
 		_ = r.Reset(bytes.NewReader(compressed))
@@ -81,18 +81,15 @@ func FuzzRoundTrip(f *testing.F) {
 
 func FuzzNewReader(f *testing.F) {
 	// Seed with valid compressed data.
-	e := NewEncoder()
+	e := mustEncoder(f)
 	f.Add(e.AppendCompress(nil, []byte("test")))
 	f.Add(e.AppendCompress(nil, []byte("testtesttesttesttesttesttesttest")))
 	f.Add(e.AppendCompress(nil, bytes.Repeat([]byte{0}, 100000)))
 	f.Add(e.AppendCompress(nil, []byte{}))
 	f.Add([]byte{0x28, 0xb5, 0x2f, 0xfd}) // just magic
-	d := NewDecoder()
 	// Cap window to prevent OOM on crafted frames.
-	if err := d.SetMaxWindowSize(1 << 20); err != nil {
-		f.Fatal(err)
-	}
-	r := NewReader(nil, d)
+	d := mustDecoder(f, WithDecoderMaxWindow(1<<20))
+	r := mustReader(f, nil, WithDecoderMaxWindow(1<<20))
 	defer r.Close()
 	var dst []byte
 
@@ -121,10 +118,8 @@ func FuzzStreamRoundTrip(f *testing.F) {
 	f.Add([]byte{0, 0}, []byte{})
 	f.Add([]byte{9, 5}, bytes.Repeat([]byte("abcdef"), 1000))
 	f.Add([]byte{0x85, 0xff}, make([]byte, 65536))
-	e := NewEncoder()
-	w := NewWriter(nil, e)
-	d := NewDecoder()
-	r := NewReader(nil, d)
+	d := mustDecoder(f)
+	r := mustReader(f, nil)
 
 	f.Fuzz(func(t *testing.T, cfg, data []byte) {
 		if len(cfg) != 2 {
@@ -141,10 +136,7 @@ func FuzzStreamRoundTrip(f *testing.F) {
 		}
 
 		var buf bytes.Buffer
-		_ = e.SetLevel(level)
-		e.SetCRC(crc)
-		e.SetLowMemory(lowMem)
-		w.Reset(&buf)
+		w := mustWriter(t, &buf, WithEncoderLevel(level), WithEncoderCRC(crc), WithLowMemory(lowMem))
 		_, _ = w.Write(data[:split])
 		_ = w.Flush()
 		_, _ = w.Write(data[split:])
@@ -198,9 +190,6 @@ func FuzzDictRoundTrip(f *testing.F) {
 	f.Add([]byte{3, 10}, bytes.Repeat([]byte("the quick brown fox "), 50))
 	f.Add([]byte{0, 0}, []byte("small"))
 	f.Add([]byte{0, 0}, []byte("smallsmallsmallsmallsmall"))
-	e := NewEncoder()
-	d := NewDecoder()
-
 	f.Fuzz(func(t *testing.T, cfg, data []byte) {
 		if len(cfg) < 2 || len(data) < 2 {
 			return
@@ -214,12 +203,10 @@ func FuzzDictRoundTrip(f *testing.F) {
 		dictPart := data[:dictSplit]
 		dataPart := data[dictSplit:]
 
-		_ = e.SetLevel(level)
-		e.SetCRC(crc)
-		e.SetRawDict(dictPart)
+		e := mustEncoder(t, WithEncoderLevel(level), WithEncoderCRC(crc), WithEncoderRawDict(dictPart))
 		compressed := e.AppendCompress(nil, dataPart)
 
-		d.SetRawDict(dictPart)
+		d := mustDecoder(t, WithDecoderRawDict(dictPart))
 		got, err := d.AppendDecompress(nil, compressed)
 		if err != nil {
 			t.Fatalf("decode: %v", err)
@@ -267,20 +254,17 @@ func FuzzReaderReset(f *testing.F) {
 	f.Add(byte(3), []byte("hello reset world"))
 	f.Add(byte(0), []byte{})
 	f.Add(byte(9), bytes.Repeat([]byte("reset"), 500))
-	e := NewEncoder()
-	d := NewDecoder()
-	r := NewReader(nil, d)
+	d := mustDecoder(f)
+	r := mustReader(f, nil)
 	var buf bytes.Buffer
 
 	f.Fuzz(func(t *testing.T, levelByte byte, data []byte) {
 		level := int(levelByte) % (BestCompression + 1)
 
-		_ = e.SetLevel(level)
-		compressed1 := e.AppendCompress(nil, data)
+		compressed1 := mustEncoder(t, WithEncoderLevel(level)).AppendCompress(nil, data)
 
 		level2 := (level + 1) % (BestCompression + 1)
-		_ = e.SetLevel(level2)
-		compressed2 := e.AppendCompress(nil, data)
+		compressed2 := mustEncoder(t, WithEncoderLevel(level2)).AppendCompress(nil, data)
 
 		_ = r.Reset(bytes.NewReader(compressed1))
 		got, err := io.ReadAll(r)

--- a/reader.go
+++ b/reader.go
@@ -32,7 +32,7 @@ func (z *Reader) ensureInit() {
 		return
 	}
 	if z.cfg == nil {
-		z.cfg = NewDecoder()
+		z.cfg = &Decoder{}
 	}
 	z.cfg.ensureInit()
 	z.initialized = true
@@ -52,20 +52,20 @@ func (z *Reader) ensureInit() {
 }
 
 // NewReader creates a new Reader that decompresses from r using the
-// configuration held by d. If d is nil, default configuration is used.
+// configuration built from opts. With no options, default configuration is used.
 // If r is nil, the Reader must be pointed at a source with [Reader.Reset]
 // before streaming.
-func NewReader(r io.Reader, d *Decoder) *Reader {
-	if d == nil {
-		d = NewDecoder()
+func NewReader(r io.Reader, opts ...DecoderOption) (*Reader, error) {
+	d, err := NewDecoder(opts...)
+	if err != nil {
+		return nil, err
 	}
-	d.ensureInit()
 	z := &Reader{cfg: d}
 	z.ensureInit()
 	if r != nil {
 		z.rw.r = r
 	}
-	return z
+	return z, nil
 }
 
 // Reset discards the Reader's state and makes it read from r.

--- a/reader.go
+++ b/reader.go
@@ -136,17 +136,9 @@ func (z *Reader) Read(p []byte) (int, error) {
 			z.decodedCount = 0
 			z.frame.history.reset()
 
-			if z.frame.DictionaryID != 0 {
-				d, ok := z.cfg.dicts[z.frame.DictionaryID]
-				if !ok {
-					z.err = ErrUnknownDictionary
-					return written, z.err
-				}
-				z.frame.history.setDict(d)
-			} else if d, ok := z.cfg.dicts[0]; ok {
-				// Raw dict (ID 0): only use content for match references.
-				z.frame.history.dict = d
-				z.frame.history.decoders.dict = d.content
+			if err := applyFrameDict(z.frame, z.cfg.dicts); err != nil {
+				z.err = err
+				return written, z.err
 			}
 		}
 
@@ -259,16 +251,9 @@ func (z *Reader) WriteTo(w io.Writer) (int64, error) {
 			z.decodedCount = 0
 			z.frame.history.reset()
 
-			if z.frame.DictionaryID != 0 {
-				d, ok := z.cfg.dicts[z.frame.DictionaryID]
-				if !ok {
-					z.err = ErrUnknownDictionary
-					return written, z.err
-				}
-				z.frame.history.setDict(d)
-			} else if d, ok := z.cfg.dicts[0]; ok {
-				z.frame.history.dict = d
-				z.frame.history.decoders.dict = d.content
+			if err := applyFrameDict(z.frame, z.cfg.dicts); err != nil {
+				z.err = err
+				return written, z.err
 			}
 		}
 

--- a/reader.go
+++ b/reader.go
@@ -5,36 +5,25 @@
 package zstd
 
 import (
-	"fmt"
 	"io"
-	"sync"
 )
 
 var _ io.WriterTo = (*Reader)(nil)
 
-var (
-	frameDecPool sync.Pool
-	blockDecPool sync.Pool
-)
-
 // Reader decompresses a zstd-compressed stream.
 type Reader struct {
+	cfg   *Decoder
 	frame *frameDec
 	block *blockDec
 	rw    readerWrapper
 
-	buf          []byte
-	dicts        map[uint32]*dict
-	decodedCount uint64
-	inFrame      bool
-	frameSeen    bool
-	err          error
-	initialized  bool
-}
-
-var defaultDecoderOptions = decoderOptions{
-	maxWindowSize: 128 << 20,
-	lowMem:        true,
+	buf           []byte
+	decodedCount  uint64
+	nDecodedTotal int64
+	inFrame       bool
+	frameSeen     bool
+	err           error
+	initialized   bool
 }
 
 // ensureInit lazily initializes the Reader on first use.
@@ -42,27 +31,36 @@ func (z *Reader) ensureInit() {
 	if z.initialized {
 		return
 	}
+	if z.cfg == nil {
+		z.cfg = NewDecoder()
+	}
+	z.cfg.ensureInit()
 	z.initialized = true
 	initPredefined()
 	if frame, _ := frameDecPool.Get().(*frameDec); frame != nil {
-		frame.o = defaultDecoderOptions
+		frame.o = z.cfg.o
 		z.frame = frame
 	} else {
-		z.frame = newFrameDec(defaultDecoderOptions)
+		z.frame = newFrameDec(z.cfg.o)
 	}
 	if block, _ := blockDecPool.Get().(*blockDec); block != nil {
-		block.lowMem = true
+		block.lowMem = z.cfg.o.lowMem
 		z.block = block
 	} else {
-		z.block = &blockDec{lowMem: true}
+		z.block = &blockDec{lowMem: z.cfg.o.lowMem}
 	}
 }
 
-// NewReader creates a new Reader reading from r.
-// If r is nil, the Reader may only be used with [Reader.AppendDecompress];
-// call [Reader.Reset] before streaming.
-func NewReader(r io.Reader) *Reader {
-	z := &Reader{}
+// NewReader creates a new Reader that decompresses from r using the
+// configuration held by d. If d is nil, default configuration is used.
+// If r is nil, the Reader must be pointed at a source with [Reader.Reset]
+// before streaming.
+func NewReader(r io.Reader, d *Decoder) *Reader {
+	if d == nil {
+		d = NewDecoder()
+	}
+	d.ensureInit()
+	z := &Reader{cfg: d}
 	z.ensureInit()
 	if r != nil {
 		z.rw.r = r
@@ -84,6 +82,7 @@ func (z *Reader) Reset(r io.Reader) error {
 	z.frameSeen = false
 	z.err = nil
 	z.decodedCount = 0
+	z.nDecodedTotal = 0
 	z.frame.history.reset()
 	return nil
 }
@@ -108,6 +107,7 @@ func (z *Reader) Read(p []byte) (int, error) {
 
 		// Start a new frame if needed.
 		if !z.inFrame {
+			z.frame.o = z.cfg.o
 			err := z.frame.reset(&z.rw)
 			if err != nil {
 				if err == io.EOF {
@@ -130,13 +130,13 @@ func (z *Reader) Read(p []byte) (int, error) {
 			z.frame.history.reset()
 
 			if z.frame.DictionaryID != 0 {
-				d, ok := z.dicts[z.frame.DictionaryID]
+				d, ok := z.cfg.dicts[z.frame.DictionaryID]
 				if !ok {
 					z.err = ErrUnknownDictionary
 					return written, z.err
 				}
 				z.frame.history.setDict(d)
-			} else if d, ok := z.dicts[0]; ok {
+			} else if d, ok := z.cfg.dicts[0]; ok {
 				// Raw dict (ID 0): only use content for match references.
 				z.frame.history.dict = d
 				z.frame.history.decoders.dict = d.content
@@ -159,6 +159,11 @@ func (z *Reader) Read(p []byte) (int, error) {
 
 		decoded := z.frame.history.b[prevLen:]
 		z.decodedCount += uint64(len(decoded))
+		z.nDecodedTotal += int64(len(decoded))
+		if m := z.frame.o.maxDecodedSize; m > 0 && z.nDecodedTotal > m {
+			z.err = &ErrDecodedSizeExceeded{Allowed: m, Produced: z.nDecodedTotal}
+			return written, z.err
+		}
 
 		if z.frame.HasCheckSum {
 			_, _ = z.frame.crc.Write(decoded)
@@ -184,82 +189,6 @@ func (z *Reader) Read(p []byte) (int, error) {
 	return written, nil
 }
 
-// AppendDecompress decompresses src and appends the decompressed bytes to dst,
-// returning the extended buffer. It is a one-shot alternative to the streaming
-// Read interface.
-//
-// src may contain one or more concatenated zstd frames.
-//
-// The Reader must not be in the middle of a streaming Read; call Reset
-// before switching from streaming to one-shot use.
-//
-// Passing nil for dst allocates a new slice. Passing a non-nil dst lets the
-// caller reuse memory or prepend existing data:
-//
-//	result, err := r.AppendDecompress(existingPrefix, compressed)
-//
-// Any registered dictionaries (via AddDict or SetRawDict) apply.
-//
-// AppendDecompress is safe for concurrent use on the same Reader,
-// provided configuration methods are not called concurrently.
-func (z *Reader) AppendDecompress(dst, src []byte) ([]byte, error) {
-	z.ensureInit()
-	if z.err == ErrDecoderClosed {
-		return nil, ErrDecoderClosed
-	}
-
-	frame, _ := frameDecPool.Get().(*frameDec)
-	if frame == nil {
-		frame = newFrameDec(z.frame.o)
-	} else {
-		frame.o = z.frame.o
-	}
-	block, _ := blockDecPool.Get().(*blockDec)
-	if block == nil {
-		block = &blockDec{lowMem: z.frame.o.lowMem}
-	} else {
-		block.lowMem = z.frame.o.lowMem
-	}
-	defer func() {
-		frameDecPool.Put(frame)
-		blockDecPool.Put(block)
-	}()
-
-	frame.bBuf = byteBuf(src)
-	var frameSeen bool
-	for {
-		err := frame.reset(&frame.bBuf)
-		if err == io.EOF {
-			if !frameSeen {
-				return dst, &ErrCorrupted{msg: "empty input", err: io.ErrUnexpectedEOF}
-			}
-			return dst, nil
-		}
-		if err != nil {
-			return dst, err
-		}
-		frameSeen = true
-		frame.history.reset()
-
-		if frame.DictionaryID != 0 {
-			d, ok := z.dicts[frame.DictionaryID]
-			if !ok {
-				return dst, ErrUnknownDictionary
-			}
-			frame.history.setDict(d)
-		} else if d, ok := z.dicts[0]; ok {
-			frame.history.dict = d
-			frame.history.decoders.dict = d.content
-		}
-
-		var err2 error
-		dst, err2 = frame.runDecoder(dst, block)
-		if err2 != nil {
-			return dst, err2
-		}
-	}
-}
-
 // Close releases resources but retains configuration.
 // After Close, the Reader may be reused by calling
 // [Reader.Reset].
@@ -274,55 +203,6 @@ func (z *Reader) Close() error {
 	z.block = nil
 	z.initialized = false
 	return nil
-}
-
-// SetMaxWindowSize sets the maximum allowed window size for decoding.
-// The default is 128 MiB.
-//
-// n must be in the range [MinWindowSize, MaxWindowSize].
-func (z *Reader) SetMaxWindowSize(n int) error {
-	z.ensureInit()
-	if n < MinWindowSize || n > MaxWindowSize {
-		return fmt.Errorf("zstd: max window size %d out of range [%d, %d]", n, MinWindowSize, MaxWindowSize)
-	}
-	z.frame.o.maxWindowSize = n
-	return nil
-}
-
-// AddDict registers a dictionary for decompression.
-// Passing nil removes all previously registered dictionaries.
-// A non-nil Dict that was not created by [ParseDict] is ignored.
-func (z *Reader) AddDict(d *Dict) {
-	z.ensureInit()
-	if d == nil || d.d == nil {
-		if d == nil {
-			clear(z.dicts)
-			return
-		}
-		return
-	}
-	if z.dicts == nil {
-		z.dicts = make(map[uint32]*dict)
-	}
-	z.dicts[d.d.id] = d.d
-}
-
-// SetRawDict registers raw bytes as a dictionary with ID 0.
-// The dictionary must be at least 8 bytes; shorter values are ignored.
-// Passing nil removes all previously registered dictionaries.
-func (z *Reader) SetRawDict(b []byte) {
-	z.ensureInit()
-	if b == nil {
-		clear(z.dicts)
-		return
-	}
-	if len(b) < 8 {
-		return
-	}
-	if z.dicts == nil {
-		z.dicts = make(map[uint32]*dict)
-	}
-	z.dicts[0] = &dict{id: 0, content: b, offsets: [3]int{1, 4, 8}}
 }
 
 // WriteTo decompresses data and writes it to w until all frames are consumed
@@ -354,6 +234,7 @@ func (z *Reader) WriteTo(w io.Writer) (int64, error) {
 
 	for {
 		if !z.inFrame {
+			z.frame.o = z.cfg.o
 			err := z.frame.reset(&z.rw)
 			if err != nil {
 				if err == io.EOF {
@@ -372,13 +253,13 @@ func (z *Reader) WriteTo(w io.Writer) (int64, error) {
 			z.frame.history.reset()
 
 			if z.frame.DictionaryID != 0 {
-				d, ok := z.dicts[z.frame.DictionaryID]
+				d, ok := z.cfg.dicts[z.frame.DictionaryID]
 				if !ok {
 					z.err = ErrUnknownDictionary
 					return written, z.err
 				}
 				z.frame.history.setDict(d)
-			} else if d, ok := z.dicts[0]; ok {
+			} else if d, ok := z.cfg.dicts[0]; ok {
 				z.frame.history.dict = d
 				z.frame.history.decoders.dict = d.content
 			}
@@ -398,6 +279,11 @@ func (z *Reader) WriteTo(w io.Writer) (int64, error) {
 
 		decoded := z.frame.history.b[prevLen:]
 		z.decodedCount += uint64(len(decoded))
+		z.nDecodedTotal += int64(len(decoded))
+		if m := z.frame.o.maxDecodedSize; m > 0 && z.nDecodedTotal > m {
+			z.err = &ErrDecodedSizeExceeded{Allowed: m, Produced: z.nDecodedTotal}
+			return written, z.err
+		}
 
 		if z.frame.HasCheckSum {
 			_, _ = z.frame.crc.Write(decoded)

--- a/reader.go
+++ b/reader.go
@@ -69,12 +69,19 @@ func NewReader(r io.Reader, opts ...DecoderOption) (*Reader, error) {
 }
 
 // Reset discards the Reader's state and makes it read from r.
-// Configuration is preserved.
+// Options in opts are applied to the configuration first; any option may be
+// changed and takes effect from the next frame. With no options the current
+// configuration is preserved.
 // If r is nil, Reset is equivalent to [Reader.Close].
-func (z *Reader) Reset(r io.Reader) error {
+func (z *Reader) Reset(r io.Reader, opts ...DecoderOption) error {
 	z.ensureInit()
 	if r == nil {
 		return z.Close()
+	}
+	for _, o := range opts {
+		if err := o(z.cfg); err != nil {
+			return err
+		}
 	}
 	z.rw.r = r
 	z.buf = nil

--- a/reader_test.go
+++ b/reader_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math/rand"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/klauspost/stdgozstd/internal/xxhash"
@@ -57,294 +56,474 @@ func newXXHash(data []byte) uint64 {
 	return h.Sum64()
 }
 
-func TestReadRawBlock(t *testing.T) {
-	frame := buildRawFrame([]byte("hello"))
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "hello" {
-		t.Fatalf("got %q, want %q", got, "hello")
-	}
-}
-
-func TestReadRLEBlock(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD) // magic
-	buf = append(buf, 0x20)                   // FHD single segment
-	buf = append(buf, 0x05)                   // FCS = 5
-	// Block header: last=1, type=RLE(1), size=5
-	bh := uint32(1) | (1 << 1) | (5 << 3)
-	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
-	buf = append(buf, 'A') // repeated byte
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "AAAAA" {
-		t.Fatalf("got %q, want %q", got, "AAAAA")
-	}
-}
-
-func TestReadCompressedRawLiterals(t *testing.T) {
-	// Compressed block with raw literals and 0 sequences.
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x20) // FHD
-	buf = append(buf, 0x05) // FCS = 5
-
-	// Compressed data: literals header (raw, size=5) + "hello" + seq header (0)
-	compData := []byte{
-		5 << 3, // literals header: raw, sizeFormat=0, size=5
-		'h', 'e', 'l', 'l', 'o',
-		0x00, // 0 sequences
-	}
-	bh := uint32(1) | (2 << 1) | (uint32(len(compData)) << 3)
-	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
-	buf = append(buf, compData...)
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "hello" {
-		t.Fatalf("got %q, want %q", got, "hello")
-	}
-}
-
-func TestReadCompressedRLELiterals(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x20) // FHD
-	buf = append(buf, 0x05) // FCS = 5
-
-	// Compressed data: literals header (RLE, size=5) + 'B' + seq header (0)
-	compData := []byte{
-		(5 << 3) | 1, // literals header: RLE, sizeFormat=0, size=5
-		'B',
-		0x00, // 0 sequences
-	}
-	bh := uint32(1) | (2 << 1) | (uint32(len(compData)) << 3)
-	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
-	buf = append(buf, compData...)
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "BBBBB" {
-		t.Fatalf("got %q, want %q", got, "BBBBB")
-	}
-}
-
-func TestReadMultiBlock(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x20) // FHD
-	buf = append(buf, 0x05) // FCS = 5
-
-	// Block 1: not last, raw, size=3
-	bh1 := uint32(0) | (0 << 1) | (3 << 3)
-	buf = append(buf, byte(bh1), byte(bh1>>8), byte(bh1>>16))
-	buf = append(buf, 'a', 'b', 'c')
-
-	// Block 2: last, raw, size=2
-	bh2 := uint32(1) | (0 << 1) | (2 << 3)
-	buf = append(buf, byte(bh2), byte(bh2>>8), byte(bh2>>16))
-	buf = append(buf, 'd', 'e')
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "abcde" {
-		t.Fatalf("got %q, want %q", got, "abcde")
-	}
-}
-
-func TestReadMultiFrame(t *testing.T) {
-	frame1 := buildRawFrame([]byte("hi"))
-	frame2 := buildRawFrame([]byte("lo"))
-	data := append(frame1, frame2...)
-
-	r := NewReader(bytes.NewReader(data), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "hilo" {
-		t.Fatalf("got %q, want %q", got, "hilo")
-	}
-}
-
-func TestReadChecksum(t *testing.T) {
-	frame := buildRawFrameChecksum([]byte("abc"))
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "abc" {
-		t.Fatalf("got %q, want %q", got, "abc")
-	}
-}
-
-func TestReadBadChecksum(t *testing.T) {
-	frame := buildRawFrameChecksum([]byte("abc"))
-	// Corrupt the checksum (last 4 bytes)
-	frame[len(frame)-1] ^= 0xFF
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer func() { _ = r.Close() }()
-	_, err := io.ReadAll(r)
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
-
-func TestReadFrameSizeMismatch(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x20) // FHD
-	buf = append(buf, 0x05) // FCS says 5 bytes
-	// But only 3 bytes of content
-	bh := uint32(1) | (0 << 1) | (3 << 3)
-	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
-	buf = append(buf, 'a', 'b', 'c')
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	defer func() { _ = r.Close() }()
-	_, err := io.ReadAll(r)
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
-
-func TestReadMagicMismatch(t *testing.T) {
-	r := NewReader(bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}), nil)
-	defer func() { _ = r.Close() }()
-	_, err := io.ReadAll(r)
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
-
-func TestReadEmpty(t *testing.T) {
-	r := NewReader(bytes.NewReader(nil), nil)
-	defer func() { _ = r.Close() }()
-	_, err := io.ReadAll(r)
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-	if !errors.Is(err, io.ErrUnexpectedEOF) {
-		t.Fatalf("expected io.ErrUnexpectedEOF wrapped, got %v", err)
-	}
-}
-
-func TestReadEmptyFrame(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x20) // FHD
-	buf = append(buf, 0x00) // FCS = 0
-	// Block: last=1, raw, size=0
-	buf = append(buf, 0x01, 0x00, 0x00)
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("expected empty, got %d bytes", len(got))
-	}
-}
-
-func TestReadSkippableFrame(t *testing.T) {
-	var buf []byte
-	// Skippable frame (type 0)
-	buf = append(buf, 0x50, 0x2A, 0x4D, 0x18)
-	buf = append(buf, 0x03, 0x00, 0x00, 0x00) // skip 3 bytes
-	buf = append(buf, 0xAA, 0xBB, 0xCC)
-	// Real frame
-	buf = append(buf, buildRawFrame([]byte("hi"))...)
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "hi" {
-		t.Fatalf("got %q, want %q", got, "hi")
-	}
-}
-
-func TestReadSmallBuffer(t *testing.T) {
-	frame := buildRawFrame([]byte("hello world"))
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer func() { _ = r.Close() }()
-
-	// Read one byte at a time
-	var got []byte
-	buf := make([]byte, 1)
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			got = append(got, buf[:n]...)
-		}
-		if err == io.EOF {
-			break
-		}
+func TestReader_Read(t *testing.T) {
+	t.Run("raw_block", func(t *testing.T) {
+		frame := buildRawFrame([]byte("hello"))
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}
-	if string(got) != "hello world" {
-		t.Fatalf("got %q, want %q", got, "hello world")
-	}
+		if string(got) != "hello" {
+			t.Fatalf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("rle_block", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD) // magic
+		buf = append(buf, 0x20)                   // FHD single segment
+		buf = append(buf, 0x05)                   // FCS = 5
+		// Block header: last=1, type=RLE(1), size=5
+		bh := uint32(1) | (1 << 1) | (5 << 3)
+		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
+		buf = append(buf, 'A') // repeated byte
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "AAAAA" {
+			t.Fatalf("got %q, want %q", got, "AAAAA")
+		}
+	})
+
+	t.Run("compressed_raw_literals", func(t *testing.T) {
+		// Compressed block with raw literals and 0 sequences.
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x20) // FHD
+		buf = append(buf, 0x05) // FCS = 5
+
+		// Compressed data: literals header (raw, size=5) + "hello" + seq header (0)
+		compData := []byte{
+			5 << 3, // literals header: raw, sizeFormat=0, size=5
+			'h', 'e', 'l', 'l', 'o',
+			0x00, // 0 sequences
+		}
+		bh := uint32(1) | (2 << 1) | (uint32(len(compData)) << 3)
+		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
+		buf = append(buf, compData...)
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "hello" {
+			t.Fatalf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("compressed_rle_literals", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x20) // FHD
+		buf = append(buf, 0x05) // FCS = 5
+
+		// Compressed data: literals header (RLE, size=5) + 'B' + seq header (0)
+		compData := []byte{
+			(5 << 3) | 1, // literals header: RLE, sizeFormat=0, size=5
+			'B',
+			0x00, // 0 sequences
+		}
+		bh := uint32(1) | (2 << 1) | (uint32(len(compData)) << 3)
+		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
+		buf = append(buf, compData...)
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "BBBBB" {
+			t.Fatalf("got %q, want %q", got, "BBBBB")
+		}
+	})
+
+	t.Run("multi_block", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x20) // FHD
+		buf = append(buf, 0x05) // FCS = 5
+
+		// Block 1: not last, raw, size=3
+		bh1 := uint32(0) | (0 << 1) | (3 << 3)
+		buf = append(buf, byte(bh1), byte(bh1>>8), byte(bh1>>16))
+		buf = append(buf, 'a', 'b', 'c')
+
+		// Block 2: last, raw, size=2
+		bh2 := uint32(1) | (0 << 1) | (2 << 3)
+		buf = append(buf, byte(bh2), byte(bh2>>8), byte(bh2>>16))
+		buf = append(buf, 'd', 'e')
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "abcde" {
+			t.Fatalf("got %q, want %q", got, "abcde")
+		}
+	})
+
+	t.Run("multi_frame", func(t *testing.T) {
+		frame1 := buildRawFrame([]byte("hi"))
+		frame2 := buildRawFrame([]byte("lo"))
+		data := append(frame1, frame2...)
+
+		r := NewReader(bytes.NewReader(data), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "hilo" {
+			t.Fatalf("got %q, want %q", got, "hilo")
+		}
+	})
+
+	t.Run("checksum", func(t *testing.T) {
+		frame := buildRawFrameChecksum([]byte("abc"))
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "abc" {
+			t.Fatalf("got %q, want %q", got, "abc")
+		}
+	})
+
+	t.Run("empty_frame", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x20) // FHD
+		buf = append(buf, 0x00) // FCS = 0
+		// Block: last=1, raw, size=0
+		buf = append(buf, 0x01, 0x00, 0x00)
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected empty, got %d bytes", len(got))
+		}
+	})
+
+	t.Run("windowed_frame", func(t *testing.T) {
+		// Non-single-segment frame with explicit window descriptor
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x00) // FHD: not single segment, no checksum
+		buf = append(buf, 0x00) // window descriptor: log=10, base=1024
+		bh := uint32(1) | (0 << 1) | (5 << 3)
+		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
+		buf = append(buf, 'h', 'e', 'l', 'l', 'o')
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "hello" {
+			t.Fatalf("got %q, want %q", got, "hello")
+		}
+	})
+
+	t.Run("min_window_size", func(t *testing.T) {
+		// Frame with window descriptor encoding a size below MinWindowSize is not
+		// possible via the encoding (minimum windowLog is 10 = 1024 = MinWindowSize),
+		// so test the single-segment path: FCS=0 with SingleSegment set.
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		// FHD: not single segment, no checksum
+		buf = append(buf, 0x00)
+		// Window descriptor: log=10 base, frac=0 → 1024 (MinWindowSize). Valid.
+		buf = append(buf, 0x00)
+		bh := uint32(1) | (0 << 1) | (0 << 3)
+		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		got, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Fatal("expected empty")
+		}
+	})
+
+	t.Run("small_buffer", func(t *testing.T) {
+		frame := buildRawFrame([]byte("hello world"))
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer func() { _ = r.Close() }()
+
+		// Read one byte at a time
+		var got []byte
+		buf := make([]byte, 1)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				got = append(got, buf[:n]...)
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if string(got) != "hello world" {
+			t.Fatalf("got %q, want %q", got, "hello world")
+		}
+	})
 }
 
-func TestReadReset(t *testing.T) {
-	frame1 := buildRawFrame([]byte("first"))
-	frame2 := buildRawFrame([]byte("second"))
-
-	r := NewReader(bytes.NewReader(frame1), nil)
-	defer func() { _ = r.Close() }()
-
-	got1, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got1) != "first" {
-		t.Fatalf("got %q, want %q", got1, "first")
-	}
-
-	if err := r.Reset(bytes.NewReader(frame2)); err != nil {
-		t.Fatal(err)
-	}
-	got2, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got2) != "second" {
-		t.Fatalf("got %q, want %q", got2, "second")
-	}
+type errReader struct {
+	data []byte
+	off  int
+	err  error
 }
 
-func TestReadAfterClose(t *testing.T) {
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	if r.off >= len(r.data) {
+		return n, r.err
+	}
+	return n, nil
+}
+
+func TestReader_Read_Errors(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil), nil)
+		defer func() { _ = r.Close() }()
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("expected io.ErrUnexpectedEOF wrapped, got %v", err)
+		}
+	})
+
+	t.Run("bad_checksum", func(t *testing.T) {
+		frame := buildRawFrameChecksum([]byte("abc"))
+		// Corrupt the checksum (last 4 bytes)
+		frame[len(frame)-1] ^= 0xFF
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer func() { _ = r.Close() }()
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("frame_size_mismatch", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x20) // FHD
+		buf = append(buf, 0x05) // FCS says 5 bytes
+		// But only 3 bytes of content
+		bh := uint32(1) | (0 << 1) | (3 << 3)
+		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
+		buf = append(buf, 'a', 'b', 'c')
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		defer func() { _ = r.Close() }()
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("magic_mismatch", func(t *testing.T) {
+		r := NewReader(bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}), nil)
+		defer func() { _ = r.Close() }()
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("truncated_block_header", func(t *testing.T) {
+		// Valid frame header, then only 2 of 3 block header bytes.
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x20)
+		buf = append(buf, 0x05)
+		buf = append(buf, 0x01, 0x00) // only 2 bytes of block header
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		_, err := io.ReadAll(r)
+		r.Close()
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("truncated_block_data", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x20)
+		buf = append(buf, 0x05)
+		// Block header: last=1, raw, size=5
+		bh := uint32(1) | (0 << 1) | (5 << 3)
+		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
+		buf = append(buf, 'a', 'b') // only 2 of 5 bytes
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		_, err := io.ReadAll(r)
+		r.Close()
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("reserved_block_type", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		buf = append(buf, 0x20)
+		buf = append(buf, 0x00)
+		// Block header: last=1, type=reserved(3), size=0
+		bh := uint32(1) | (3 << 1) | (0 << 3)
+		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		_, err := io.ReadAll(r)
+		r.Close()
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("reserved_frame_header_bit", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
+		// FHD with reserved bit 3 set.
+		buf = append(buf, 0x08)
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		_, err := io.ReadAll(r)
+		r.Close()
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("only_skippable", func(t *testing.T) {
+		var buf []byte
+		buf = append(buf, 0x50, 0x2A, 0x4D, 0x18)
+		buf = append(buf, 0x01, 0x00, 0x00, 0x00)
+		buf = append(buf, 0xFF)
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		_, err := io.ReadAll(r)
+		r.Close()
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("io_error", func(t *testing.T) {
+		frame := buildRawFrame([]byte("hello world, this is data"))
+		readErr := errors.New("disk read error")
+
+		// Truncate so the reader fails mid-block.
+		er := &errReader{data: frame[:len(frame)-5], err: readErr}
+		r := NewReader(er, nil)
+		_, err := io.ReadAll(r)
+		r.Close()
+		if err == nil {
+			t.Fatal("expected error")
+		}
+
+		// Error should be sticky.
+		_, err2 := r.Read(make([]byte, 1))
+		if err2 == nil {
+			t.Fatal("expected sticky error")
+		}
+	})
+}
+
+func TestReader_Read_Skippable(t *testing.T) {
+	t.Run("single", func(t *testing.T) {
+		var buf []byte
+		// Skippable frame (type 0)
+		buf = append(buf, 0x50, 0x2A, 0x4D, 0x18)
+		buf = append(buf, 0x03, 0x00, 0x00, 0x00) // skip 3 bytes
+		buf = append(buf, 0xAA, 0xBB, 0xCC)
+		// Real frame
+		buf = append(buf, buildRawFrame([]byte("hi"))...)
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "hi" {
+			t.Fatalf("got %q, want %q", got, "hi")
+		}
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		var buf []byte
+		for i := range 3 {
+			buf = append(buf, byte(0x50+i), 0x2A, 0x4D, 0x18)
+			buf = append(buf, 0x02, 0x00, 0x00, 0x00)
+			buf = append(buf, 0xAA, 0xBB)
+		}
+		buf = append(buf, buildRawFrame([]byte("ok"))...)
+
+		r := NewReader(bytes.NewReader(buf), nil)
+		got, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "ok" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("types", func(t *testing.T) {
+		for typ := byte(0x50); typ <= 0x5F; typ++ {
+			var buf []byte
+			buf = append(buf, typ, 0x2A, 0x4D, 0x18)
+			buf = append(buf, 0x00, 0x00, 0x00, 0x00) // 0 bytes to skip
+			buf = append(buf, buildRawFrame([]byte("x"))...)
+
+			r := NewReader(bytes.NewReader(buf), nil)
+			got, err := io.ReadAll(r)
+			r.Close()
+			if err != nil {
+				t.Fatalf("type 0x%02X: %v", typ, err)
+			}
+			if string(got) != "x" {
+				t.Fatalf("type 0x%02X: got %q", typ, got)
+			}
+		}
+	})
+}
+
+func TestReader_Read_AfterClose(t *testing.T) {
 	frame := buildRawFrame([]byte("test"))
 	r := NewReader(bytes.NewReader(frame), nil)
 	_ = r.Close()
@@ -354,215 +533,298 @@ func TestReadAfterClose(t *testing.T) {
 	}
 }
 
-func TestReadWindowedFrame(t *testing.T) {
-	// Non-single-segment frame with explicit window descriptor
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x00) // FHD: not single segment, no checksum
-	buf = append(buf, 0x00) // window descriptor: log=10, base=1024
-	bh := uint32(1) | (0 << 1) | (5 << 3)
-	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
-	buf = append(buf, 'h', 'e', 'l', 'l', 'o')
+func TestReader_WriteTo(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		frame := buildRawFrame([]byte("hello"))
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer r.Close()
+		var buf bytes.Buffer
+		n, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 5 || buf.String() != "hello" {
+			t.Fatalf("got %d %q, want 5 %q", n, buf.String(), "hello")
+		}
+	})
 
-	r := NewReader(bytes.NewReader(buf), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "hello" {
-		t.Fatalf("got %q, want %q", got, "hello")
-	}
-}
+	t.Run("empty_frame", func(t *testing.T) {
+		var frame []byte
+		frame = append(frame, 0x28, 0xB5, 0x2F, 0xFD)
+		frame = append(frame, 0x20)
+		frame = append(frame, 0x00)
+		frame = append(frame, 0x01, 0x00, 0x00)
 
-func TestNewReaderNilInput(t *testing.T) {
-	r := NewReader(nil, nil)
-	frame := buildRawFrame([]byte("after nil"))
-	if err := r.Reset(bytes.NewReader(frame)); err != nil {
-		t.Fatal(err)
-	}
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "after nil" {
-		t.Fatalf("got %q, want %q", got, "after nil")
-	}
-	r.Close()
-}
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer r.Close()
+		var buf bytes.Buffer
+		n, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 || buf.Len() != 0 {
+			t.Fatalf("got %d bytes, want 0", n)
+		}
+	})
 
-func TestReaderResetNilClosesReader(t *testing.T) {
-	r := NewReader(bytes.NewReader(buildRawFrame([]byte("x"))), nil)
-	if err := r.Reset(nil); err != nil {
-		t.Fatal(err)
-	}
-	_, err := r.Read(make([]byte, 1))
-	if err != ErrDecoderClosed {
-		t.Fatalf("expected ErrDecoderClosed after Reset(nil), got %v", err)
-	}
-}
+	t.Run("multi_block", func(t *testing.T) {
+		var frame []byte
+		frame = append(frame, 0x28, 0xB5, 0x2F, 0xFD)
+		frame = append(frame, 0x20)
+		frame = append(frame, 0x05)
+		bh1 := uint32(0) | (0 << 1) | (3 << 3)
+		frame = append(frame, byte(bh1), byte(bh1>>8), byte(bh1>>16))
+		frame = append(frame, 'a', 'b', 'c')
+		bh2 := uint32(1) | (0 << 1) | (2 << 3)
+		frame = append(frame, byte(bh2), byte(bh2>>8), byte(bh2>>16))
+		frame = append(frame, 'd', 'e')
 
-func TestWriteToBasic(t *testing.T) {
-	frame := buildRawFrame([]byte("hello"))
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 5 || buf.String() != "hello" {
-		t.Fatalf("got %d %q, want 5 %q", n, buf.String(), "hello")
-	}
-}
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer r.Close()
+		var buf bytes.Buffer
+		n, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 5 || buf.String() != "abcde" {
+			t.Fatalf("got %d %q, want 5 %q", n, buf.String(), "abcde")
+		}
+	})
 
-func TestWriteToEmpty(t *testing.T) {
-	r := NewReader(bytes.NewReader(nil), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	_, err := r.WriteTo(&buf)
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-	if !errors.Is(err, io.ErrUnexpectedEOF) {
-		t.Fatalf("expected io.ErrUnexpectedEOF wrapped, got %v", err)
-	}
-}
+	t.Run("multi_frame", func(t *testing.T) {
+		data := append(buildRawFrame([]byte("hi")), buildRawFrame([]byte("lo"))...)
+		r := NewReader(bytes.NewReader(data), nil)
+		defer r.Close()
+		var buf bytes.Buffer
+		n, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 4 || buf.String() != "hilo" {
+			t.Fatalf("got %d %q, want 4 %q", n, buf.String(), "hilo")
+		}
+	})
 
-func TestWriteToEmptyFrame(t *testing.T) {
-	var frame []byte
-	frame = append(frame, 0x28, 0xB5, 0x2F, 0xFD)
-	frame = append(frame, 0x20)
-	frame = append(frame, 0x00)
-	frame = append(frame, 0x01, 0x00, 0x00)
+	t.Run("checksum", func(t *testing.T) {
+		frame := buildRawFrameChecksum([]byte("abc"))
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer r.Close()
+		var buf bytes.Buffer
+		n, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 3 || buf.String() != "abc" {
+			t.Fatalf("got %d %q, want 3 %q", n, buf.String(), "abc")
+		}
+	})
 
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 0 || buf.Len() != 0 {
-		t.Fatalf("got %d bytes, want 0", n)
-	}
-}
+	t.Run("compressed", func(t *testing.T) {
+		src := bytes.Repeat([]byte("compressed data for WriteTo test "), 100)
+		for level := BestSpeed; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				e := NewEncoder()
+				if err := e.SetLevel(level); err != nil {
+					t.Fatal(err)
+				}
+				compressed := e.AppendCompress(nil, src)
 
-func TestWriteToMultiBlock(t *testing.T) {
-	var frame []byte
-	frame = append(frame, 0x28, 0xB5, 0x2F, 0xFD)
-	frame = append(frame, 0x20)
-	frame = append(frame, 0x05)
-	bh1 := uint32(0) | (0 << 1) | (3 << 3)
-	frame = append(frame, byte(bh1), byte(bh1>>8), byte(bh1>>16))
-	frame = append(frame, 'a', 'b', 'c')
-	bh2 := uint32(1) | (0 << 1) | (2 << 3)
-	frame = append(frame, byte(bh2), byte(bh2>>8), byte(bh2>>16))
-	frame = append(frame, 'd', 'e')
+				r := NewReader(bytes.NewReader(compressed), nil)
+				defer r.Close()
+				var buf bytes.Buffer
+				_, err := r.WriteTo(&buf)
+				if err != nil {
+					t.Fatalf("level %d: %v", level, err)
+				}
+				if !bytes.Equal(buf.Bytes(), src) {
+					t.Fatalf("level %d: mismatch: got %d, want %d bytes", level, buf.Len(), len(src))
+				}
+			})
+		}
+	})
 
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 5 || buf.String() != "abcde" {
-		t.Fatalf("got %d %q, want 5 %q", n, buf.String(), "abcde")
-	}
-}
+	t.Run("compressed_multi_block", func(t *testing.T) {
+		// > 128KB to force multiple blocks.
+		src := make([]byte, maxCompressedBlockSize*2+5000)
+		for i := range src {
+			src[i] = byte(i % 251)
+		}
+		for level := BestSpeed; level <= BestCompression; level++ {
+			e := NewEncoder()
+			_ = e.SetLevel(level)
+			compressed := e.AppendCompress(nil, src)
 
-func TestWriteToMultiFrame(t *testing.T) {
-	data := append(buildRawFrame([]byte("hi")), buildRawFrame([]byte("lo"))...)
-	r := NewReader(bytes.NewReader(data), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 4 || buf.String() != "hilo" {
-		t.Fatalf("got %d %q, want 4 %q", n, buf.String(), "hilo")
-	}
-}
+			r := NewReader(bytes.NewReader(compressed), nil)
+			var buf bytes.Buffer
+			n, err := r.WriteTo(&buf)
+			r.Close()
+			if err != nil {
+				t.Fatalf("level %d: %v", level, err)
+			}
+			if n != int64(len(src)) {
+				t.Fatalf("level %d: wrote %d, want %d", level, n, len(src))
+			}
+			if !bytes.Equal(buf.Bytes(), src) {
+				t.Fatalf("level %d: mismatch", level)
+			}
+		}
+	})
 
-func TestWriteToChecksum(t *testing.T) {
-	frame := buildRawFrameChecksum([]byte("abc"))
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 3 || buf.String() != "abc" {
-		t.Fatalf("got %d %q, want 3 %q", n, buf.String(), "abc")
-	}
-}
+	t.Run("large", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42))
+		src := make([]byte, 1<<20)
+		rng.Read(src)
 
-func TestWriteToBadChecksum(t *testing.T) {
-	frame := buildRawFrameChecksum([]byte("abc"))
-	frame[len(frame)-1] ^= 0xFF
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	_, err := r.WriteTo(&buf)
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
+		e := NewEncoder()
+		compressed := e.AppendCompress(nil, src)
 
-func TestWriteToFrameSizeMismatch(t *testing.T) {
-	var frame []byte
-	frame = append(frame, 0x28, 0xB5, 0x2F, 0xFD)
-	frame = append(frame, 0x20)
-	frame = append(frame, 0x05) // FCS says 5
-	bh := uint32(1) | (0 << 1) | (3 << 3)
-	frame = append(frame, byte(bh), byte(bh>>8), byte(bh>>16))
-	frame = append(frame, 'a', 'b', 'c') // only 3 bytes
+		r := NewReader(bytes.NewReader(compressed), nil)
+		defer r.Close()
+		var buf bytes.Buffer
+		n, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != int64(len(src)) {
+			t.Fatalf("wrote %d, want %d", n, len(src))
+		}
+		if !bytes.Equal(buf.Bytes(), src) {
+			t.Fatal("content mismatch")
+		}
+	})
 
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	_, err := r.WriteTo(&buf)
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
+	t.Run("dict", func(t *testing.T) {
+		dictContent := bytes.Repeat([]byte("dictionary prefix content here! "), 100)
+		src := append([]byte{}, dictContent[500:1500]...)
+		src = append(src, []byte("and some unique new content")...)
+		src = bytes.Repeat(src, 10)
 
-func TestWriteToAfterClose(t *testing.T) {
-	r := NewReader(bytes.NewReader(buildRawFrame([]byte("test"))), nil)
-	r.Close()
-	_, err := r.WriteTo(&bytes.Buffer{})
-	if err != ErrDecoderClosed {
-		t.Fatalf("expected ErrDecoderClosed, got %v", err)
-	}
-}
+		t.Run("raw", func(t *testing.T) {
+			e := NewEncoder()
+			e.SetRawDict(dictContent)
+			compressed := e.AppendCompress(nil, src)
 
-func TestWriteToAfterPartialRead(t *testing.T) {
-	frame := buildRawFrame([]byte("hello world"))
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer r.Close()
+			dec := NewDecoder()
+			dec.SetRawDict(dictContent)
+			r := NewReader(bytes.NewReader(compressed), dec)
+			defer r.Close()
+			var buf bytes.Buffer
+			_, err := r.WriteTo(&buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(buf.Bytes(), src) {
+				t.Fatal("raw dict mismatch")
+			}
+		})
 
-	// Read only 5 bytes.
-	p := make([]byte, 5)
-	n, err := r.Read(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(p[:n]) != "hello" {
-		t.Fatalf("partial read: got %q, want %q", p[:n], "hello")
-	}
+		t.Run("parsed", func(t *testing.T) {
+			raw, err := os.ReadFile("testdata/d0.dict")
+			if err != nil {
+				t.Fatal(err)
+			}
+			d, err := ParseDict(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			e := NewEncoder()
+			e.AddDict(d)
+			compressed := e.AppendCompress(nil, src)
 
-	// WriteTo should drain remaining.
-	var buf bytes.Buffer
-	wn, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if wn != 6 || buf.String() != " world" {
-		t.Fatalf("got %d %q, want 6 %q", wn, buf.String(), " world")
-	}
+			dec := NewDecoder()
+			dec.AddDict(d)
+			r := NewReader(bytes.NewReader(compressed), dec)
+			defer r.Close()
+			var buf bytes.Buffer
+			_, err = r.WriteTo(&buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(buf.Bytes(), src) {
+				t.Fatal("parsed dict mismatch")
+			}
+		})
+	})
+
+	t.Run("skippable", func(t *testing.T) {
+		var data []byte
+		// Skippable frame (type 0)
+		data = append(data, 0x50, 0x2A, 0x4D, 0x18)
+		data = append(data, 0x03, 0x00, 0x00, 0x00)
+		data = append(data, 0xAA, 0xBB, 0xCC)
+		// Real frame
+		data = append(data, buildRawFrame([]byte("hi"))...)
+
+		r := NewReader(bytes.NewReader(data), nil)
+		defer r.Close()
+		var buf bytes.Buffer
+		n, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 2 || buf.String() != "hi" {
+			t.Fatalf("got %d %q, want 2 %q", n, buf.String(), "hi")
+		}
+	})
+
+	t.Run("matches_read_all", func(t *testing.T) {
+		inputs := [][]byte{
+			[]byte("hello"),
+			bytes.Repeat([]byte("x"), 1000),
+			{},
+		}
+		for _, src := range inputs {
+			e := NewEncoder()
+			compressed := e.AppendCompress(nil, src)
+
+			// ReadAll
+			r1 := NewReader(bytes.NewReader(compressed), nil)
+			readResult, err := io.ReadAll(r1)
+			r1.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// WriteTo
+			r2 := NewReader(bytes.NewReader(compressed), nil)
+			var buf bytes.Buffer
+			_, err = r2.WriteTo(&buf)
+			r2.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(readResult, buf.Bytes()) {
+				t.Fatalf("ReadAll vs WriteTo mismatch for input len %d", len(src))
+			}
+		}
+	})
+
+	t.Run("after_partial_read", func(t *testing.T) {
+		frame := buildRawFrame([]byte("hello world"))
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer r.Close()
+
+		// Read only 5 bytes.
+		p := make([]byte, 5)
+		n, err := r.Read(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(p[:n]) != "hello" {
+			t.Fatalf("partial read: got %q, want %q", p[:n], "hello")
+		}
+
+		// WriteTo should drain remaining.
+		var buf bytes.Buffer
+		wn, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if wn != 6 || buf.String() != " world" {
+			t.Fatalf("got %d %q, want 6 %q", wn, buf.String(), " world")
+		}
+	})
 }
 
 type errWriter struct {
@@ -579,297 +841,288 @@ func (w *errWriter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-func TestWriteToWriteError(t *testing.T) {
-	frame := buildRawFrame([]byte("hello world"))
-	r := NewReader(bytes.NewReader(frame), nil)
-	defer r.Close()
-
-	writeErr := errors.New("disk full")
-	ew := &errWriter{n: 0, err: writeErr}
-	_, err := r.WriteTo(ew)
-	if err != writeErr {
-		t.Fatalf("expected writeErr, got %v", err)
-	}
-
-	// Error should be sticky.
-	_, err = r.WriteTo(&bytes.Buffer{})
-	if err != writeErr {
-		t.Fatalf("expected sticky error, got %v", err)
-	}
-}
-
-func TestWriteToCompressed(t *testing.T) {
-	src := bytes.Repeat([]byte("compressed data for WriteTo test "), 100)
-	for level := BestSpeed; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			e := NewEncoder()
-			if err := e.SetLevel(level); err != nil {
-				t.Fatal(err)
-			}
-			compressed := e.AppendCompress(nil, src)
-
-			r := NewReader(bytes.NewReader(compressed), nil)
-			defer r.Close()
-			var buf bytes.Buffer
-			_, err := r.WriteTo(&buf)
-			if err != nil {
-				t.Fatalf("level %d: %v", level, err)
-			}
-			if !bytes.Equal(buf.Bytes(), src) {
-				t.Fatalf("level %d: mismatch: got %d, want %d bytes", level, buf.Len(), len(src))
-			}
-		})
-	}
-}
-
-func TestWriteToLarge(t *testing.T) {
-	rng := rand.New(rand.NewSource(42))
-	src := make([]byte, 1<<20)
-	rng.Read(src)
-
-	e := NewEncoder()
-	compressed := e.AppendCompress(nil, src)
-
-	r := NewReader(bytes.NewReader(compressed), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != int64(len(src)) {
-		t.Fatalf("wrote %d, want %d", n, len(src))
-	}
-	if !bytes.Equal(buf.Bytes(), src) {
-		t.Fatal("content mismatch")
-	}
-}
-
-func TestWriteToDict(t *testing.T) {
-	dictContent := bytes.Repeat([]byte("dictionary prefix content here! "), 100)
-	src := append([]byte{}, dictContent[500:1500]...)
-	src = append(src, []byte("and some unique new content")...)
-	src = bytes.Repeat(src, 10)
-
-	t.Run("raw", func(t *testing.T) {
-		e := NewEncoder()
-		e.SetRawDict(dictContent)
-		compressed := e.AppendCompress(nil, src)
-
-		dec := NewDecoder()
-		dec.SetRawDict(dictContent)
-		r := NewReader(bytes.NewReader(compressed), dec)
+func TestReader_WriteTo_Errors(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil), nil)
 		defer r.Close()
 		var buf bytes.Buffer
 		_, err := r.WriteTo(&buf)
-		if err != nil {
-			t.Fatal(err)
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
 		}
-		if !bytes.Equal(buf.Bytes(), src) {
-			t.Fatal("raw dict mismatch")
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("expected io.ErrUnexpectedEOF wrapped, got %v", err)
 		}
 	})
 
-	t.Run("parsed", func(t *testing.T) {
-		raw, err := os.ReadFile("testdata/d0.dict")
-		if err != nil {
-			t.Fatal(err)
-		}
-		d, err := ParseDict(raw)
-		if err != nil {
-			t.Fatal(err)
-		}
-		e := NewEncoder()
-		e.AddDict(d)
-		compressed := e.AppendCompress(nil, src)
-
-		dec := NewDecoder()
-		dec.AddDict(d)
-		r := NewReader(bytes.NewReader(compressed), dec)
+	t.Run("bad_checksum", func(t *testing.T) {
+		frame := buildRawFrameChecksum([]byte("abc"))
+		frame[len(frame)-1] ^= 0xFF
+		r := NewReader(bytes.NewReader(frame), nil)
 		defer r.Close()
 		var buf bytes.Buffer
-		_, err = r.WriteTo(&buf)
-		if err != nil {
-			t.Fatal(err)
+		_, err := r.WriteTo(&buf)
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
 		}
-		if !bytes.Equal(buf.Bytes(), src) {
-			t.Fatal("parsed dict mismatch")
+	})
+
+	t.Run("frame_size_mismatch", func(t *testing.T) {
+		var frame []byte
+		frame = append(frame, 0x28, 0xB5, 0x2F, 0xFD)
+		frame = append(frame, 0x20)
+		frame = append(frame, 0x05) // FCS says 5
+		bh := uint32(1) | (0 << 1) | (3 << 3)
+		frame = append(frame, byte(bh), byte(bh>>8), byte(bh>>16))
+		frame = append(frame, 'a', 'b', 'c') // only 3 bytes
+
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer r.Close()
+		var buf bytes.Buffer
+		_, err := r.WriteTo(&buf)
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatalf("expected ErrCorrupted, got %v", err)
+		}
+	})
+
+	t.Run("after_close", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(buildRawFrame([]byte("test"))), nil)
+		r.Close()
+		_, err := r.WriteTo(&bytes.Buffer{})
+		if err != ErrDecoderClosed {
+			t.Fatalf("expected ErrDecoderClosed, got %v", err)
+		}
+	})
+
+	t.Run("write_error", func(t *testing.T) {
+		frame := buildRawFrame([]byte("hello world"))
+		r := NewReader(bytes.NewReader(frame), nil)
+		defer r.Close()
+
+		writeErr := errors.New("disk full")
+		ew := &errWriter{n: 0, err: writeErr}
+		_, err := r.WriteTo(ew)
+		if err != writeErr {
+			t.Fatalf("expected writeErr, got %v", err)
+		}
+
+		// Error should be sticky.
+		_, err = r.WriteTo(&bytes.Buffer{})
+		if err != writeErr {
+			t.Fatalf("expected sticky error, got %v", err)
+		}
+	})
+
+	t.Run("partial_write_error", func(t *testing.T) {
+		src := bytes.Repeat([]byte("partial write test "), 500)
+		e := NewEncoder()
+		compressed := e.AppendCompress(nil, src)
+
+		writeErr := errors.New("out of space")
+		r := NewReader(bytes.NewReader(compressed), nil)
+		// Accept 0 bytes — fail immediately.
+		ew := &errWriter{n: 0, err: writeErr}
+		_, err := r.WriteTo(ew)
+		r.Close()
+		if err != writeErr {
+			t.Fatalf("expected writeErr, got %v", err)
 		}
 	})
 }
 
-func TestReaderReuseAfterClose(t *testing.T) {
-	frame1 := buildRawFrame([]byte("before"))
-	frame2 := buildRawFrame([]byte("after"))
+func TestReader_Reset(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		frame1 := buildRawFrame([]byte("first"))
+		frame2 := buildRawFrame([]byte("second"))
 
-	r := NewReader(bytes.NewReader(frame1), nil)
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "before" {
-		t.Fatalf("got %q, want %q", got, "before")
-	}
+		r := NewReader(bytes.NewReader(frame1), nil)
+		defer func() { _ = r.Close() }()
 
-	r.Close()
+		got1, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got1) != "first" {
+			t.Fatalf("got %q, want %q", got1, "first")
+		}
 
-	if err := r.Reset(bytes.NewReader(frame2)); err != nil {
-		t.Fatal(err)
-	}
-	got, err = io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "after" {
-		t.Fatalf("got %q, want %q", got, "after")
-	}
-}
+		if err := r.Reset(bytes.NewReader(frame2)); err != nil {
+			t.Fatal(err)
+		}
+		got2, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got2) != "second" {
+			t.Fatalf("got %q, want %q", got2, "second")
+		}
+	})
 
-func TestReaderReuseAfterCloseWriteTo(t *testing.T) {
-	frame1 := buildRawFrame([]byte("before"))
-	frame2 := buildRawFrame([]byte("after"))
-
-	r := NewReader(bytes.NewReader(frame1), nil)
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "before" {
-		t.Fatalf("got %q, want %q", got, "before")
-	}
-
-	r.Close()
-
-	if err := r.Reset(bytes.NewReader(frame2)); err != nil {
-		t.Fatal(err)
-	}
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 5 || buf.String() != "after" {
-		t.Fatalf("got %d %q, want 5 %q", n, buf.String(), "after")
-	}
-}
-
-func TestReaderReuseAfterCloseAppendCompress(t *testing.T) {
-	frame1 := buildRawFrame([]byte("before"))
-	frame2 := buildRawFrame([]byte("after"))
-
-	dec := NewDecoder()
-	r := NewReader(bytes.NewReader(frame1), dec)
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "before" {
-		t.Fatalf("got %q, want %q", got, "before")
-	}
-
-	r.Close()
-
-	if err := r.Reset(bytes.NewReader(nil)); err != nil {
-		t.Fatal(err)
-	}
-	result, err := dec.AppendDecompress(nil, frame2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(result) != "after" {
-		t.Fatalf("got %q, want %q", result, "after")
-	}
-}
-
-func TestReaderReuseAfterCloseMultiple(t *testing.T) {
-	r := NewReader(bytes.NewReader(buildRawFrame([]byte("init"))), nil)
-
-	for i := range 5 {
-		want := []byte{byte('A' + i), byte('0' + i)}
-		frame := buildRawFrame(want)
-
+	t.Run("nil_input", func(t *testing.T) {
+		r := NewReader(nil, nil)
+		frame := buildRawFrame([]byte("after nil"))
 		if err := r.Reset(bytes.NewReader(frame)); err != nil {
-			t.Fatalf("cycle %d reset: %v", i, err)
+			t.Fatal(err)
 		}
 		got, err := io.ReadAll(r)
 		if err != nil {
-			t.Fatalf("cycle %d read: %v", i, err)
+			t.Fatal(err)
 		}
-		if !bytes.Equal(got, want) {
-			t.Fatalf("cycle %d: got %q, want %q", i, got, want)
+		if string(got) != "after nil" {
+			t.Fatalf("got %q, want %q", got, "after nil")
 		}
 		r.Close()
-	}
-}
+	})
 
-func TestWriteToMatchesReadAll(t *testing.T) {
-	inputs := [][]byte{
-		[]byte("hello"),
-		bytes.Repeat([]byte("x"), 1000),
-		{},
-	}
-	for _, src := range inputs {
-		e := NewEncoder()
-		compressed := e.AppendCompress(nil, src)
+	t.Run("nil_closes", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(buildRawFrame([]byte("x"))), nil)
+		if err := r.Reset(nil); err != nil {
+			t.Fatal(err)
+		}
+		_, err := r.Read(make([]byte, 1))
+		if err != ErrDecoderClosed {
+			t.Fatalf("expected ErrDecoderClosed after Reset(nil), got %v", err)
+		}
+	})
 
-		// ReadAll
-		r1 := NewReader(bytes.NewReader(compressed), nil)
-		readResult, err := io.ReadAll(r1)
-		r1.Close()
+	t.Run("reuse_after_close", func(t *testing.T) {
+		frame1 := buildRawFrame([]byte("before"))
+		frame2 := buildRawFrame([]byte("after"))
+
+		r := NewReader(bytes.NewReader(frame1), nil)
+		got, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
 		}
+		if string(got) != "before" {
+			t.Fatalf("got %q, want %q", got, "before")
+		}
 
-		// WriteTo
-		r2 := NewReader(bytes.NewReader(compressed), nil)
+		r.Close()
+
+		if err := r.Reset(bytes.NewReader(frame2)); err != nil {
+			t.Fatal(err)
+		}
+		got, err = io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "after" {
+			t.Fatalf("got %q, want %q", got, "after")
+		}
+	})
+
+	t.Run("reuse_after_close_writeto", func(t *testing.T) {
+		frame1 := buildRawFrame([]byte("before"))
+		frame2 := buildRawFrame([]byte("after"))
+
+		r := NewReader(bytes.NewReader(frame1), nil)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "before" {
+			t.Fatalf("got %q, want %q", got, "before")
+		}
+
+		r.Close()
+
+		if err := r.Reset(bytes.NewReader(frame2)); err != nil {
+			t.Fatal(err)
+		}
 		var buf bytes.Buffer
-		_, err = r2.WriteTo(&buf)
-		r2.Close()
+		n, err := r.WriteTo(&buf)
 		if err != nil {
 			t.Fatal(err)
 		}
-
-		if !bytes.Equal(readResult, buf.Bytes()) {
-			t.Fatalf("ReadAll vs WriteTo mismatch for input len %d", len(src))
+		if n != 5 || buf.String() != "after" {
+			t.Fatalf("got %d %q, want 5 %q", n, buf.String(), "after")
 		}
-	}
+	})
+
+	t.Run("reuse_after_close_append_decompress", func(t *testing.T) {
+		frame1 := buildRawFrame([]byte("before"))
+		frame2 := buildRawFrame([]byte("after"))
+
+		dec := NewDecoder()
+		r := NewReader(bytes.NewReader(frame1), dec)
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "before" {
+			t.Fatalf("got %q, want %q", got, "before")
+		}
+
+		r.Close()
+
+		if err := r.Reset(bytes.NewReader(nil)); err != nil {
+			t.Fatal(err)
+		}
+		result, err := dec.AppendDecompress(nil, frame2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(result) != "after" {
+			t.Fatalf("got %q, want %q", result, "after")
+		}
+	})
+
+	t.Run("reuse_multiple", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(buildRawFrame([]byte("init"))), nil)
+
+		for i := range 5 {
+			want := []byte{byte('A' + i), byte('0' + i)}
+			frame := buildRawFrame(want)
+
+			if err := r.Reset(bytes.NewReader(frame)); err != nil {
+				t.Fatalf("cycle %d reset: %v", i, err)
+			}
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatalf("cycle %d read: %v", i, err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("cycle %d: got %q, want %q", i, got, want)
+			}
+			r.Close()
+		}
+	})
 }
 
-func TestWriteToSkippableFrame(t *testing.T) {
-	var data []byte
-	// Skippable frame (type 0)
-	data = append(data, 0x50, 0x2A, 0x4D, 0x18)
-	data = append(data, 0x03, 0x00, 0x00, 0x00)
-	data = append(data, 0xAA, 0xBB, 0xCC)
-	// Real frame
-	data = append(data, buildRawFrame([]byte("hi"))...)
+func TestReader_ZeroValue(t *testing.T) {
+	t.Run("read", func(t *testing.T) {
+		frame := buildRawFrame([]byte("zero value"))
+		var r Reader
+		if err := r.Reset(bytes.NewReader(frame)); err != nil {
+			t.Fatal(err)
+		}
+		got, err := io.ReadAll(&r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "zero value" {
+			t.Fatalf("got %q, want %q", got, "zero value")
+		}
+		r.Close()
+	})
 
-	r := NewReader(bytes.NewReader(data), nil)
-	defer r.Close()
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 2 || buf.String() != "hi" {
-		t.Fatalf("got %d %q, want 2 %q", n, buf.String(), "hi")
-	}
-}
-
-func TestZeroValueReader(t *testing.T) {
-	frame := buildRawFrame([]byte("zero value"))
-	var r Reader
-	if err := r.Reset(bytes.NewReader(frame)); err != nil {
-		t.Fatal(err)
-	}
-	got, err := io.ReadAll(&r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "zero value" {
-		t.Fatalf("got %q, want %q", got, "zero value")
-	}
-	r.Close()
+	t.Run("write_to", func(t *testing.T) {
+		frame := buildRawFrame([]byte("zero writeto"))
+		var r Reader
+		if err := r.Reset(bytes.NewReader(frame)); err != nil {
+			t.Fatal(err)
+		}
+		var buf bytes.Buffer
+		n, err := r.WriteTo(&buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 12 || buf.String() != "zero writeto" {
+			t.Fatalf("got %d %q", n, buf.String())
+		}
+		r.Close()
+	})
 }
 
 func TestSetMaxWindowSize(t *testing.T) {
@@ -912,331 +1165,6 @@ func TestSetMaxWindowSizeMax(t *testing.T) {
 	}
 	if !bytes.Equal(got, src) {
 		t.Fatal("mismatch")
-	}
-}
-
-func TestSetMaxWindowSizeValidation(t *testing.T) {
-	d := NewDecoder()
-	if err := d.SetMaxWindowSize(0); err == nil {
-		t.Fatal("expected error for 0")
-	}
-	if err := d.SetMaxWindowSize(-1); err == nil {
-		t.Fatal("expected error for -1")
-	}
-	if err := d.SetMaxWindowSize(MaxWindowSize + 1); err == nil {
-		t.Fatal("expected error for too large")
-	}
-	if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
-		t.Fatalf("MinWindowSize should be valid: %v", err)
-	}
-	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
-		t.Fatalf("MaxWindowSize should be valid: %v", err)
-	}
-}
-
-func TestReadTruncatedBlockHeader(t *testing.T) {
-	// Valid frame header, then only 2 of 3 block header bytes.
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x20)
-	buf = append(buf, 0x05)
-	buf = append(buf, 0x01, 0x00) // only 2 bytes of block header
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	_, err := io.ReadAll(r)
-	r.Close()
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
-
-func TestReadTruncatedBlockData(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x20)
-	buf = append(buf, 0x05)
-	// Block header: last=1, raw, size=5
-	bh := uint32(1) | (0 << 1) | (5 << 3)
-	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
-	buf = append(buf, 'a', 'b') // only 2 of 5 bytes
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	_, err := io.ReadAll(r)
-	r.Close()
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
-
-func TestReadReservedBlockType(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	buf = append(buf, 0x20)
-	buf = append(buf, 0x00)
-	// Block header: last=1, type=reserved(3), size=0
-	bh := uint32(1) | (3 << 1) | (0 << 3)
-	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	_, err := io.ReadAll(r)
-	r.Close()
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
-
-func TestReadWindowSizeTooSmall(t *testing.T) {
-	// Frame with window descriptor encoding a size below MinWindowSize is not
-	// possible via the encoding (minimum windowLog is 10 = 1024 = MinWindowSize),
-	// so test the single-segment path: FCS=0 with SingleSegment set.
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	// FHD: not single segment, no checksum
-	buf = append(buf, 0x00)
-	// Window descriptor: log=10 base, frac=0 → 1024 (MinWindowSize). Valid.
-	buf = append(buf, 0x00)
-	bh := uint32(1) | (0 << 1) | (0 << 3)
-	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 0 {
-		t.Fatal("expected empty")
-	}
-}
-
-func TestReadReservedFrameHeaderBit(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x28, 0xB5, 0x2F, 0xFD)
-	// FHD with reserved bit 3 set.
-	buf = append(buf, 0x08)
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	_, err := io.ReadAll(r)
-	r.Close()
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
-
-type errReader struct {
-	data []byte
-	off  int
-	err  error
-}
-
-func (r *errReader) Read(p []byte) (int, error) {
-	if r.off >= len(r.data) {
-		return 0, r.err
-	}
-	n := copy(p, r.data[r.off:])
-	r.off += n
-	if r.off >= len(r.data) {
-		return n, r.err
-	}
-	return n, nil
-}
-
-func TestReadIOError(t *testing.T) {
-	frame := buildRawFrame([]byte("hello world, this is data"))
-	readErr := errors.New("disk read error")
-
-	// Truncate so the reader fails mid-block.
-	er := &errReader{data: frame[:len(frame)-5], err: readErr}
-	r := NewReader(er, nil)
-	_, err := io.ReadAll(r)
-	r.Close()
-	if err == nil {
-		t.Fatal("expected error")
-	}
-
-	// Error should be sticky.
-	_, err2 := r.Read(make([]byte, 1))
-	if err2 == nil {
-		t.Fatal("expected sticky error")
-	}
-}
-
-func TestReadMultipleSkippableFrames(t *testing.T) {
-	var buf []byte
-	for i := range 3 {
-		buf = append(buf, byte(0x50+i), 0x2A, 0x4D, 0x18)
-		buf = append(buf, 0x02, 0x00, 0x00, 0x00)
-		buf = append(buf, 0xAA, 0xBB)
-	}
-	buf = append(buf, buildRawFrame([]byte("ok"))...)
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "ok" {
-		t.Fatalf("got %q", got)
-	}
-}
-
-func TestReadOnlySkippableFrames(t *testing.T) {
-	var buf []byte
-	buf = append(buf, 0x50, 0x2A, 0x4D, 0x18)
-	buf = append(buf, 0x01, 0x00, 0x00, 0x00)
-	buf = append(buf, 0xFF)
-
-	r := NewReader(bytes.NewReader(buf), nil)
-	_, err := io.ReadAll(r)
-	r.Close()
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatalf("expected ErrCorrupted, got %v", err)
-	}
-}
-
-func TestReadSkippableFrameTypes(t *testing.T) {
-	for typ := byte(0x50); typ <= 0x5F; typ++ {
-		var buf []byte
-		buf = append(buf, typ, 0x2A, 0x4D, 0x18)
-		buf = append(buf, 0x00, 0x00, 0x00, 0x00) // 0 bytes to skip
-		buf = append(buf, buildRawFrame([]byte("x"))...)
-
-		r := NewReader(bytes.NewReader(buf), nil)
-		got, err := io.ReadAll(r)
-		r.Close()
-		if err != nil {
-			t.Fatalf("type 0x%02X: %v", typ, err)
-		}
-		if string(got) != "x" {
-			t.Fatalf("type 0x%02X: got %q", typ, got)
-		}
-	}
-}
-
-func TestAppendDecompressPreExistingDst(t *testing.T) {
-	src := []byte("appended after prefix")
-	e := NewEncoder()
-	compressed := e.AppendCompress(nil, src)
-
-	var d Decoder
-	prefix := []byte("PREFIX:")
-	got, err := d.AppendDecompress(prefix, compressed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "PREFIX:appended after prefix" {
-		t.Fatalf("got %q", got)
-	}
-}
-
-func TestAppendDecompressConcurrentDifferentData(t *testing.T) {
-	e := NewEncoder()
-	d := NewDecoder()
-
-	const goroutines = 8
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	errs := make(chan error, goroutines)
-
-	for i := range goroutines {
-		src := bytes.Repeat([]byte{byte('A' + i)}, 5000)
-		compressed := e.AppendCompress(nil, src)
-		go func() {
-			defer wg.Done()
-			got, err := d.AppendDecompress(nil, compressed)
-			if err != nil {
-				errs <- err
-				return
-			}
-			if !bytes.Equal(got, src) {
-				errs <- errors.New("mismatch")
-			}
-		}()
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Fatal(err)
-	}
-}
-
-func TestAppendDecompressLargeFrame(t *testing.T) {
-	// > 1 MiB to exercise the non-prealloc path in runDecoder.
-	rng := rand.New(rand.NewSource(99))
-	src := make([]byte, 1<<20+50000)
-	rng.Read(src)
-
-	e := NewEncoder()
-	compressed := e.AppendCompress(nil, src)
-
-	var d Decoder
-	got, err := d.AppendDecompress(nil, compressed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestAppendDecompressMultiFrameWithCRC(t *testing.T) {
-	e := NewEncoder()
-	e.SetCRC(true)
-	frame1 := e.AppendCompress(nil, []byte("frame one "))
-	frame2 := e.AppendCompress(nil, []byte("frame two"))
-	combined := append(frame1, frame2...)
-
-	var d Decoder
-	got, err := d.AppendDecompress(nil, combined)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "frame one frame two" {
-		t.Fatalf("got %q", got)
-	}
-}
-
-func TestWriteToCompressedMultiBlock(t *testing.T) {
-	// > 128KB to force multiple blocks.
-	src := make([]byte, maxCompressedBlockSize*2+5000)
-	for i := range src {
-		src[i] = byte(i % 251)
-	}
-	for level := BestSpeed; level <= BestCompression; level++ {
-		e := NewEncoder()
-		_ = e.SetLevel(level)
-		compressed := e.AppendCompress(nil, src)
-
-		r := NewReader(bytes.NewReader(compressed), nil)
-		var buf bytes.Buffer
-		n, err := r.WriteTo(&buf)
-		r.Close()
-		if err != nil {
-			t.Fatalf("level %d: %v", level, err)
-		}
-		if n != int64(len(src)) {
-			t.Fatalf("level %d: wrote %d, want %d", level, n, len(src))
-		}
-		if !bytes.Equal(buf.Bytes(), src) {
-			t.Fatalf("level %d: mismatch", level)
-		}
-	}
-}
-
-func TestWriteToPartialWriteError(t *testing.T) {
-	src := bytes.Repeat([]byte("partial write test "), 500)
-	e := NewEncoder()
-	compressed := e.AppendCompress(nil, src)
-
-	writeErr := errors.New("out of space")
-	r := NewReader(bytes.NewReader(compressed), nil)
-	// Accept 0 bytes — fail immediately.
-	ew := &errWriter{n: 0, err: writeErr}
-	_, err := r.WriteTo(ew)
-	r.Close()
-	if err != writeErr {
-		t.Fatalf("expected writeErr, got %v", err)
 	}
 }
 
@@ -1305,107 +1233,5 @@ func TestSetMaxSizeWriteToNoFlush(t *testing.T) {
 	}
 	if n != 0 || out.Len() != 0 {
 		t.Fatalf("over-budget data leaked to writer: n=%d out=%d", n, out.Len())
-	}
-}
-
-// TestSetMaxSizeMultiFrame verifies the limit is cumulative across concatenated
-// frames within a single AppendDecompress call.
-func TestSetMaxSizeMultiFrame(t *testing.T) {
-	part := bytes.Repeat([]byte("frame "), 500)
-	e := NewEncoder()
-	var concatenated []byte
-	concatenated = e.AppendCompress(concatenated, part)
-	concatenated = e.AppendCompress(concatenated, part)
-
-	d := NewDecoder()
-	// Enough for one frame but not both.
-	if err := d.SetMaxSize(int64(len(part)) + 100); err != nil {
-		t.Fatal(err)
-	}
-	_, err := d.AppendDecompress(nil, concatenated)
-	var de *ErrDecodedSizeExceeded
-	if !errors.As(err, &de) {
-		t.Fatalf("expected cumulative ErrDecodedSizeExceeded, got %v", err)
-	}
-
-	// Enough for both frames succeeds.
-	if err := d.SetMaxSize(int64(2 * len(part))); err != nil {
-		t.Fatal(err)
-	}
-	got, err := d.AppendDecompress(nil, concatenated)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := append(append([]byte{}, part...), part...)
-	if !bytes.Equal(got, want) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestDecoderReuseAcrossReaders(t *testing.T) {
-	e := NewEncoder()
-	uno := bytes.Repeat([]byte("uno "), 300)
-	dos := bytes.Repeat([]byte("dos "), 300)
-	f1 := e.AppendCompress(nil, uno)
-	f2 := e.AppendCompress(nil, dos)
-
-	d := NewDecoder()
-	for _, tc := range []struct{ frame, want []byte }{{f1, uno}, {f2, dos}} {
-		r := NewReader(bytes.NewReader(tc.frame), d)
-		got, err := io.ReadAll(r)
-		_ = r.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(got, tc.want) {
-			t.Fatal("mismatch")
-		}
-	}
-}
-
-// TestDecoderReconfigureBetweenStreams tightens then loosens the max window on a
-// bound Decoder between Reset cycles and verifies the new limit is honored.
-func TestDecoderReconfigureBetweenStreams(t *testing.T) {
-	src := bytes.Repeat([]byte("decoder reconfigure "), 300)
-	compressed := NewEncoder().AppendCompress(nil, src)
-
-	d := NewDecoder()
-	r := NewReader(bytes.NewReader(compressed), d)
-
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-
-	// Tighten the SAME decoder, reuse the SAME reader: must now fail.
-	if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
-		t.Fatal(err)
-	}
-	_, err = io.ReadAll(r)
-	var we *ErrWindowSizeExceeded
-	if !errors.As(err, &we) {
-		t.Fatalf("expected ErrWindowSizeExceeded after tightening, got %v", err)
-	}
-
-	// Loosen again: succeeds.
-	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
-		t.Fatal(err)
-	}
-	got, err = io.ReadAll(r)
-	_ = r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
 	}
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -59,7 +59,7 @@ func newXXHash(data []byte) uint64 {
 
 func TestReadRawBlock(t *testing.T) {
 	frame := buildRawFrame([]byte("hello"))
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -80,7 +80,7 @@ func TestReadRLEBlock(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, 'A') // repeated byte
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -108,7 +108,7 @@ func TestReadCompressedRawLiterals(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, compData...)
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -135,7 +135,7 @@ func TestReadCompressedRLELiterals(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, compData...)
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -162,7 +162,7 @@ func TestReadMultiBlock(t *testing.T) {
 	buf = append(buf, byte(bh2), byte(bh2>>8), byte(bh2>>16))
 	buf = append(buf, 'd', 'e')
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -178,7 +178,7 @@ func TestReadMultiFrame(t *testing.T) {
 	frame2 := buildRawFrame([]byte("lo"))
 	data := append(frame1, frame2...)
 
-	r := NewReader(bytes.NewReader(data))
+	r := NewReader(bytes.NewReader(data), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -191,7 +191,7 @@ func TestReadMultiFrame(t *testing.T) {
 
 func TestReadChecksum(t *testing.T) {
 	frame := buildRawFrameChecksum([]byte("abc"))
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -206,7 +206,7 @@ func TestReadBadChecksum(t *testing.T) {
 	frame := buildRawFrameChecksum([]byte("abc"))
 	// Corrupt the checksum (last 4 bytes)
 	frame[len(frame)-1] ^= 0xFF
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer func() { _ = r.Close() }()
 	_, err := io.ReadAll(r)
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -224,7 +224,7 @@ func TestReadFrameSizeMismatch(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, 'a', 'b', 'c')
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	defer func() { _ = r.Close() }()
 	_, err := io.ReadAll(r)
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -233,7 +233,7 @@ func TestReadFrameSizeMismatch(t *testing.T) {
 }
 
 func TestReadMagicMismatch(t *testing.T) {
-	r := NewReader(bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}))
+	r := NewReader(bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}), nil)
 	defer func() { _ = r.Close() }()
 	_, err := io.ReadAll(r)
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -242,7 +242,7 @@ func TestReadMagicMismatch(t *testing.T) {
 }
 
 func TestReadEmpty(t *testing.T) {
-	r := NewReader(bytes.NewReader(nil))
+	r := NewReader(bytes.NewReader(nil), nil)
 	defer func() { _ = r.Close() }()
 	_, err := io.ReadAll(r)
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -261,7 +261,7 @@ func TestReadEmptyFrame(t *testing.T) {
 	// Block: last=1, raw, size=0
 	buf = append(buf, 0x01, 0x00, 0x00)
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -281,7 +281,7 @@ func TestReadSkippableFrame(t *testing.T) {
 	// Real frame
 	buf = append(buf, buildRawFrame([]byte("hi"))...)
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -294,7 +294,7 @@ func TestReadSkippableFrame(t *testing.T) {
 
 func TestReadSmallBuffer(t *testing.T) {
 	frame := buildRawFrame([]byte("hello world"))
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer func() { _ = r.Close() }()
 
 	// Read one byte at a time
@@ -321,7 +321,7 @@ func TestReadReset(t *testing.T) {
 	frame1 := buildRawFrame([]byte("first"))
 	frame2 := buildRawFrame([]byte("second"))
 
-	r := NewReader(bytes.NewReader(frame1))
+	r := NewReader(bytes.NewReader(frame1), nil)
 	defer func() { _ = r.Close() }()
 
 	got1, err := io.ReadAll(r)
@@ -346,7 +346,7 @@ func TestReadReset(t *testing.T) {
 
 func TestReadAfterClose(t *testing.T) {
 	frame := buildRawFrame([]byte("test"))
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	_ = r.Close()
 	_, err := r.Read(make([]byte, 10))
 	if err != ErrDecoderClosed {
@@ -364,7 +364,7 @@ func TestReadWindowedFrame(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, 'h', 'e', 'l', 'l', 'o')
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -376,7 +376,7 @@ func TestReadWindowedFrame(t *testing.T) {
 }
 
 func TestNewReaderNilInput(t *testing.T) {
-	r := NewReader(nil)
+	r := NewReader(nil, nil)
 	frame := buildRawFrame([]byte("after nil"))
 	if err := r.Reset(bytes.NewReader(frame)); err != nil {
 		t.Fatal(err)
@@ -392,7 +392,7 @@ func TestNewReaderNilInput(t *testing.T) {
 }
 
 func TestReaderResetNilClosesReader(t *testing.T) {
-	r := NewReader(bytes.NewReader(buildRawFrame([]byte("x"))))
+	r := NewReader(bytes.NewReader(buildRawFrame([]byte("x"))), nil)
 	if err := r.Reset(nil); err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +404,7 @@ func TestReaderResetNilClosesReader(t *testing.T) {
 
 func TestWriteToBasic(t *testing.T) {
 	frame := buildRawFrame([]byte("hello"))
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -417,7 +417,7 @@ func TestWriteToBasic(t *testing.T) {
 }
 
 func TestWriteToEmpty(t *testing.T) {
-	r := NewReader(bytes.NewReader(nil))
+	r := NewReader(bytes.NewReader(nil), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	_, err := r.WriteTo(&buf)
@@ -436,7 +436,7 @@ func TestWriteToEmptyFrame(t *testing.T) {
 	frame = append(frame, 0x00)
 	frame = append(frame, 0x01, 0x00, 0x00)
 
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -460,7 +460,7 @@ func TestWriteToMultiBlock(t *testing.T) {
 	frame = append(frame, byte(bh2), byte(bh2>>8), byte(bh2>>16))
 	frame = append(frame, 'd', 'e')
 
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -474,7 +474,7 @@ func TestWriteToMultiBlock(t *testing.T) {
 
 func TestWriteToMultiFrame(t *testing.T) {
 	data := append(buildRawFrame([]byte("hi")), buildRawFrame([]byte("lo"))...)
-	r := NewReader(bytes.NewReader(data))
+	r := NewReader(bytes.NewReader(data), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -488,7 +488,7 @@ func TestWriteToMultiFrame(t *testing.T) {
 
 func TestWriteToChecksum(t *testing.T) {
 	frame := buildRawFrameChecksum([]byte("abc"))
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -503,7 +503,7 @@ func TestWriteToChecksum(t *testing.T) {
 func TestWriteToBadChecksum(t *testing.T) {
 	frame := buildRawFrameChecksum([]byte("abc"))
 	frame[len(frame)-1] ^= 0xFF
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	_, err := r.WriteTo(&buf)
@@ -521,7 +521,7 @@ func TestWriteToFrameSizeMismatch(t *testing.T) {
 	frame = append(frame, byte(bh), byte(bh>>8), byte(bh>>16))
 	frame = append(frame, 'a', 'b', 'c') // only 3 bytes
 
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	_, err := r.WriteTo(&buf)
@@ -531,7 +531,7 @@ func TestWriteToFrameSizeMismatch(t *testing.T) {
 }
 
 func TestWriteToAfterClose(t *testing.T) {
-	r := NewReader(bytes.NewReader(buildRawFrame([]byte("test"))))
+	r := NewReader(bytes.NewReader(buildRawFrame([]byte("test"))), nil)
 	r.Close()
 	_, err := r.WriteTo(&bytes.Buffer{})
 	if err != ErrDecoderClosed {
@@ -541,7 +541,7 @@ func TestWriteToAfterClose(t *testing.T) {
 
 func TestWriteToAfterPartialRead(t *testing.T) {
 	frame := buildRawFrame([]byte("hello world"))
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer r.Close()
 
 	// Read only 5 bytes.
@@ -581,7 +581,7 @@ func (w *errWriter) Write(p []byte) (int, error) {
 
 func TestWriteToWriteError(t *testing.T) {
 	frame := buildRawFrame([]byte("hello world"))
-	r := NewReader(bytes.NewReader(frame))
+	r := NewReader(bytes.NewReader(frame), nil)
 	defer r.Close()
 
 	writeErr := errors.New("disk full")
@@ -602,13 +602,13 @@ func TestWriteToCompressed(t *testing.T) {
 	src := bytes.Repeat([]byte("compressed data for WriteTo test "), 100)
 	for level := BestSpeed; level <= BestCompression; level++ {
 		t.Run("", func(t *testing.T) {
-			w := NewWriter(nil)
-			if err := w.SetLevel(level); err != nil {
+			e := NewEncoder()
+			if err := e.SetLevel(level); err != nil {
 				t.Fatal(err)
 			}
-			compressed := w.AppendCompress(nil, src)
+			compressed := e.AppendCompress(nil, src)
 
-			r := NewReader(bytes.NewReader(compressed))
+			r := NewReader(bytes.NewReader(compressed), nil)
 			defer r.Close()
 			var buf bytes.Buffer
 			_, err := r.WriteTo(&buf)
@@ -627,10 +627,10 @@ func TestWriteToLarge(t *testing.T) {
 	src := make([]byte, 1<<20)
 	rng.Read(src)
 
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -652,13 +652,14 @@ func TestWriteToDict(t *testing.T) {
 	src = bytes.Repeat(src, 10)
 
 	t.Run("raw", func(t *testing.T) {
-		w := NewWriter(nil)
-		w.SetRawDict(dictContent)
-		compressed := w.AppendCompress(nil, src)
+		e := NewEncoder()
+		e.SetRawDict(dictContent)
+		compressed := e.AppendCompress(nil, src)
 
-		r := NewReader(bytes.NewReader(compressed))
+		dec := NewDecoder()
+		dec.SetRawDict(dictContent)
+		r := NewReader(bytes.NewReader(compressed), dec)
 		defer r.Close()
-		r.SetRawDict(dictContent)
 		var buf bytes.Buffer
 		_, err := r.WriteTo(&buf)
 		if err != nil {
@@ -678,13 +679,14 @@ func TestWriteToDict(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		w := NewWriter(nil)
-		w.AddDict(d)
-		compressed := w.AppendCompress(nil, src)
+		e := NewEncoder()
+		e.AddDict(d)
+		compressed := e.AppendCompress(nil, src)
 
-		r := NewReader(bytes.NewReader(compressed))
+		dec := NewDecoder()
+		dec.AddDict(d)
+		r := NewReader(bytes.NewReader(compressed), dec)
 		defer r.Close()
-		r.AddDict(d)
 		var buf bytes.Buffer
 		_, err = r.WriteTo(&buf)
 		if err != nil {
@@ -700,7 +702,7 @@ func TestReaderReuseAfterClose(t *testing.T) {
 	frame1 := buildRawFrame([]byte("before"))
 	frame2 := buildRawFrame([]byte("after"))
 
-	r := NewReader(bytes.NewReader(frame1))
+	r := NewReader(bytes.NewReader(frame1), nil)
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -727,7 +729,7 @@ func TestReaderReuseAfterCloseWriteTo(t *testing.T) {
 	frame1 := buildRawFrame([]byte("before"))
 	frame2 := buildRawFrame([]byte("after"))
 
-	r := NewReader(bytes.NewReader(frame1))
+	r := NewReader(bytes.NewReader(frame1), nil)
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -755,7 +757,8 @@ func TestReaderReuseAfterCloseAppendCompress(t *testing.T) {
 	frame1 := buildRawFrame([]byte("before"))
 	frame2 := buildRawFrame([]byte("after"))
 
-	r := NewReader(bytes.NewReader(frame1))
+	dec := NewDecoder()
+	r := NewReader(bytes.NewReader(frame1), dec)
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
@@ -769,7 +772,7 @@ func TestReaderReuseAfterCloseAppendCompress(t *testing.T) {
 	if err := r.Reset(bytes.NewReader(nil)); err != nil {
 		t.Fatal(err)
 	}
-	result, err := r.AppendDecompress(nil, frame2)
+	result, err := dec.AppendDecompress(nil, frame2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -779,7 +782,7 @@ func TestReaderReuseAfterCloseAppendCompress(t *testing.T) {
 }
 
 func TestReaderReuseAfterCloseMultiple(t *testing.T) {
-	r := NewReader(bytes.NewReader(buildRawFrame([]byte("init"))))
+	r := NewReader(bytes.NewReader(buildRawFrame([]byte("init"))), nil)
 
 	for i := range 5 {
 		want := []byte{byte('A' + i), byte('0' + i)}
@@ -806,11 +809,11 @@ func TestWriteToMatchesReadAll(t *testing.T) {
 		{},
 	}
 	for _, src := range inputs {
-		w := NewWriter(nil)
-		compressed := w.AppendCompress(nil, src)
+		e := NewEncoder()
+		compressed := e.AppendCompress(nil, src)
 
 		// ReadAll
-		r1 := NewReader(bytes.NewReader(compressed))
+		r1 := NewReader(bytes.NewReader(compressed), nil)
 		readResult, err := io.ReadAll(r1)
 		r1.Close()
 		if err != nil {
@@ -818,7 +821,7 @@ func TestWriteToMatchesReadAll(t *testing.T) {
 		}
 
 		// WriteTo
-		r2 := NewReader(bytes.NewReader(compressed))
+		r2 := NewReader(bytes.NewReader(compressed), nil)
 		var buf bytes.Buffer
 		_, err = r2.WriteTo(&buf)
 		r2.Close()
@@ -841,7 +844,7 @@ func TestWriteToSkippableFrame(t *testing.T) {
 	// Real frame
 	data = append(data, buildRawFrame([]byte("hi"))...)
 
-	r := NewReader(bytes.NewReader(data))
+	r := NewReader(bytes.NewReader(data), nil)
 	defer r.Close()
 	var buf bytes.Buffer
 	n, err := r.WriteTo(&buf)
@@ -869,75 +872,18 @@ func TestZeroValueReader(t *testing.T) {
 	r.Close()
 }
 
-func TestZeroValueReaderAppendCompress(t *testing.T) {
-	frame := buildRawFrame([]byte("decode zero"))
-	var r Reader
-	got, err := r.AppendDecompress(nil, frame)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "decode zero" {
-		t.Fatalf("got %q, want %q", got, "decode zero")
-	}
-	r.Close()
-}
-
-func TestAppendDecompressConcurrent(t *testing.T) {
-	src := bytes.Repeat([]byte("concurrent decompress test data! "), 500)
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
-
-	r := NewReader(nil)
-
-	const goroutines = 8
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	errs := make(chan error, goroutines)
-
-	for range goroutines {
-		go func() {
-			defer wg.Done()
-			got, err := r.AppendDecompress(nil, compressed)
-			if err != nil {
-				errs <- err
-				return
-			}
-			if !bytes.Equal(got, src) {
-				errs <- bytes.ErrTooLarge
-			}
-		}()
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Fatal(err)
-	}
-}
-
-func TestAppendDecompressEmpty(t *testing.T) {
-	var r Reader
-	for _, src := range [][]byte{nil, {}} {
-		_, err := r.AppendDecompress(nil, src)
-		if !errors.Is(err, &ErrCorrupted{}) {
-			t.Fatalf("expected ErrCorrupted for %v, got %v", src, err)
-		}
-		if !errors.Is(err, io.ErrUnexpectedEOF) {
-			t.Fatalf("expected io.ErrUnexpectedEOF wrapped for %v, got %v", src, err)
-		}
-	}
-}
-
 func TestSetMaxWindowSize(t *testing.T) {
 	// Compress with default window (~4 MiB at level 3).
 	src := bytes.Repeat([]byte("window size test "), 200)
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	enc := NewEncoder()
+	compressed := enc.AppendCompress(nil, src)
 
 	// Decoding with a tiny max window should fail.
-	r := NewReader(bytes.NewReader(compressed))
-	if err := r.SetMaxWindowSize(MinWindowSize); err != nil {
+	d := NewDecoder()
+	if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
 		t.Fatal(err)
 	}
+	r := NewReader(bytes.NewReader(compressed), d)
 	_, err := io.ReadAll(r)
 	r.Close()
 	var e *ErrWindowSizeExceeded
@@ -951,13 +897,14 @@ func TestSetMaxWindowSize(t *testing.T) {
 
 func TestSetMaxWindowSizeMax(t *testing.T) {
 	src := bytes.Repeat([]byte("max window "), 200)
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
-	if err := r.SetMaxWindowSize(MaxWindowSize); err != nil {
+	d := NewDecoder()
+	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
 		t.Fatal(err)
 	}
+	r := NewReader(bytes.NewReader(compressed), d)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -969,23 +916,22 @@ func TestSetMaxWindowSizeMax(t *testing.T) {
 }
 
 func TestSetMaxWindowSizeValidation(t *testing.T) {
-	r := NewReader(nil)
-	if err := r.SetMaxWindowSize(0); err == nil {
+	d := NewDecoder()
+	if err := d.SetMaxWindowSize(0); err == nil {
 		t.Fatal("expected error for 0")
 	}
-	if err := r.SetMaxWindowSize(-1); err == nil {
+	if err := d.SetMaxWindowSize(-1); err == nil {
 		t.Fatal("expected error for -1")
 	}
-	if err := r.SetMaxWindowSize(MaxWindowSize + 1); err == nil {
+	if err := d.SetMaxWindowSize(MaxWindowSize + 1); err == nil {
 		t.Fatal("expected error for too large")
 	}
-	if err := r.SetMaxWindowSize(MinWindowSize); err != nil {
+	if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
 		t.Fatalf("MinWindowSize should be valid: %v", err)
 	}
-	if err := r.SetMaxWindowSize(MaxWindowSize); err != nil {
+	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
 		t.Fatalf("MaxWindowSize should be valid: %v", err)
 	}
-	r.Close()
 }
 
 func TestReadTruncatedBlockHeader(t *testing.T) {
@@ -996,7 +942,7 @@ func TestReadTruncatedBlockHeader(t *testing.T) {
 	buf = append(buf, 0x05)
 	buf = append(buf, 0x01, 0x00) // only 2 bytes of block header
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1014,7 +960,7 @@ func TestReadTruncatedBlockData(t *testing.T) {
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 	buf = append(buf, 'a', 'b') // only 2 of 5 bytes
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1031,7 +977,7 @@ func TestReadReservedBlockType(t *testing.T) {
 	bh := uint32(1) | (3 << 1) | (0 << 3)
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1052,7 +998,7 @@ func TestReadWindowSizeTooSmall(t *testing.T) {
 	bh := uint32(1) | (0 << 1) | (0 << 3)
 	buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1069,7 +1015,7 @@ func TestReadReservedFrameHeaderBit(t *testing.T) {
 	// FHD with reserved bit 3 set.
 	buf = append(buf, 0x08)
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1101,7 +1047,7 @@ func TestReadIOError(t *testing.T) {
 
 	// Truncate so the reader fails mid-block.
 	er := &errReader{data: frame[:len(frame)-5], err: readErr}
-	r := NewReader(er)
+	r := NewReader(er, nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	if err == nil {
@@ -1124,7 +1070,7 @@ func TestReadMultipleSkippableFrames(t *testing.T) {
 	}
 	buf = append(buf, buildRawFrame([]byte("ok"))...)
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1141,7 +1087,7 @@ func TestReadOnlySkippableFrames(t *testing.T) {
 	buf = append(buf, 0x01, 0x00, 0x00, 0x00)
 	buf = append(buf, 0xFF)
 
-	r := NewReader(bytes.NewReader(buf))
+	r := NewReader(bytes.NewReader(buf), nil)
 	_, err := io.ReadAll(r)
 	r.Close()
 	if !errors.Is(err, &ErrCorrupted{}) {
@@ -1156,7 +1102,7 @@ func TestReadSkippableFrameTypes(t *testing.T) {
 		buf = append(buf, 0x00, 0x00, 0x00, 0x00) // 0 bytes to skip
 		buf = append(buf, buildRawFrame([]byte("x"))...)
 
-		r := NewReader(bytes.NewReader(buf))
+		r := NewReader(bytes.NewReader(buf), nil)
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -1170,12 +1116,12 @@ func TestReadSkippableFrameTypes(t *testing.T) {
 
 func TestAppendDecompressPreExistingDst(t *testing.T) {
 	src := []byte("appended after prefix")
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	var r Reader
+	var d Decoder
 	prefix := []byte("PREFIX:")
-	got, err := r.AppendDecompress(prefix, compressed)
+	got, err := d.AppendDecompress(prefix, compressed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1185,8 +1131,8 @@ func TestAppendDecompressPreExistingDst(t *testing.T) {
 }
 
 func TestAppendDecompressConcurrentDifferentData(t *testing.T) {
-	w := NewWriter(nil)
-	r := NewReader(nil)
+	e := NewEncoder()
+	d := NewDecoder()
 
 	const goroutines = 8
 	var wg sync.WaitGroup
@@ -1195,10 +1141,10 @@ func TestAppendDecompressConcurrentDifferentData(t *testing.T) {
 
 	for i := range goroutines {
 		src := bytes.Repeat([]byte{byte('A' + i)}, 5000)
-		compressed := w.AppendCompress(nil, src)
+		compressed := e.AppendCompress(nil, src)
 		go func() {
 			defer wg.Done()
-			got, err := r.AppendDecompress(nil, compressed)
+			got, err := d.AppendDecompress(nil, compressed)
 			if err != nil {
 				errs <- err
 				return
@@ -1221,11 +1167,11 @@ func TestAppendDecompressLargeFrame(t *testing.T) {
 	src := make([]byte, 1<<20+50000)
 	rng.Read(src)
 
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	var r Reader
-	got, err := r.AppendDecompress(nil, compressed)
+	var d Decoder
+	got, err := d.AppendDecompress(nil, compressed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1235,14 +1181,14 @@ func TestAppendDecompressLargeFrame(t *testing.T) {
 }
 
 func TestAppendDecompressMultiFrameWithCRC(t *testing.T) {
-	w := NewWriter(nil)
-	w.SetCRC(true)
-	frame1 := w.AppendCompress(nil, []byte("frame one "))
-	frame2 := w.AppendCompress(nil, []byte("frame two"))
+	e := NewEncoder()
+	e.SetCRC(true)
+	frame1 := e.AppendCompress(nil, []byte("frame one "))
+	frame2 := e.AppendCompress(nil, []byte("frame two"))
 	combined := append(frame1, frame2...)
 
-	var r Reader
-	got, err := r.AppendDecompress(nil, combined)
+	var d Decoder
+	got, err := d.AppendDecompress(nil, combined)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1258,11 +1204,11 @@ func TestWriteToCompressedMultiBlock(t *testing.T) {
 		src[i] = byte(i % 251)
 	}
 	for level := BestSpeed; level <= BestCompression; level++ {
-		w := NewWriter(nil)
-		_ = w.SetLevel(level)
-		compressed := w.AppendCompress(nil, src)
+		e := NewEncoder()
+		_ = e.SetLevel(level)
+		compressed := e.AppendCompress(nil, src)
 
-		r := NewReader(bytes.NewReader(compressed))
+		r := NewReader(bytes.NewReader(compressed), nil)
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
 		r.Close()
@@ -1280,16 +1226,186 @@ func TestWriteToCompressedMultiBlock(t *testing.T) {
 
 func TestWriteToPartialWriteError(t *testing.T) {
 	src := bytes.Repeat([]byte("partial write test "), 500)
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
 	writeErr := errors.New("out of space")
-	r := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed), nil)
 	// Accept 0 bytes — fail immediately.
 	ew := &errWriter{n: 0, err: writeErr}
 	_, err := r.WriteTo(ew)
 	r.Close()
 	if err != writeErr {
 		t.Fatalf("expected writeErr, got %v", err)
+	}
+}
+
+// TestSetMaxSizeStreamingRead covers the running per-block check on the streaming
+// Read path and its sticky-error behavior.
+func TestSetMaxSizeStreamingRead(t *testing.T) {
+	src := bytes.Repeat([]byte("streaming decode bomb guard "), 12000) // multi-block
+	var buf bytes.Buffer
+	w := NewWriter(&buf, nil)
+	if _, err := w.Write(src); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	compressed := buf.Bytes()
+
+	d := NewDecoder()
+	if err := d.SetMaxSize(int64(len(src)) / 2); err != nil {
+		t.Fatal(err)
+	}
+	r := NewReader(bytes.NewReader(compressed), d)
+	_, err := io.ReadAll(r)
+	var de *ErrDecodedSizeExceeded
+	if !errors.As(err, &de) {
+		t.Fatalf("expected ErrDecodedSizeExceeded, got %v", err)
+	}
+	// The error is sticky until Reset.
+	if _, err := r.Read(make([]byte, 8)); !errors.As(err, &de) {
+		t.Fatalf("limit error must be sticky, got %v", err)
+	}
+	_ = r.Close()
+
+	// Raising the limit on the same decoder and resetting the reader succeeds.
+	if err := d.SetMaxSize(int64(len(src))); err != nil {
+		t.Fatal(err)
+	}
+	r = NewReader(bytes.NewReader(compressed), d)
+	got, err := io.ReadAll(r)
+	_ = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch")
+	}
+}
+
+// TestSetMaxSizeWriteToNoFlush verifies an over-limit frame produces no output
+// through WriteTo (the guard runs before the block is written).
+func TestSetMaxSizeWriteToNoFlush(t *testing.T) {
+	src := bytes.Repeat([]byte("x"), 4000)
+	compressed := NewEncoder().AppendCompress(nil, src)
+
+	d := NewDecoder()
+	if err := d.SetMaxSize(int64(len(src)) - 1); err != nil {
+		t.Fatal(err)
+	}
+	r := NewReader(bytes.NewReader(compressed), d)
+	var out bytes.Buffer
+	n, err := r.WriteTo(&out)
+	_ = r.Close()
+	var de *ErrDecodedSizeExceeded
+	if !errors.As(err, &de) {
+		t.Fatalf("expected ErrDecodedSizeExceeded, got %v", err)
+	}
+	if n != 0 || out.Len() != 0 {
+		t.Fatalf("over-budget data leaked to writer: n=%d out=%d", n, out.Len())
+	}
+}
+
+// TestSetMaxSizeMultiFrame verifies the limit is cumulative across concatenated
+// frames within a single AppendDecompress call.
+func TestSetMaxSizeMultiFrame(t *testing.T) {
+	part := bytes.Repeat([]byte("frame "), 500)
+	e := NewEncoder()
+	var concatenated []byte
+	concatenated = e.AppendCompress(concatenated, part)
+	concatenated = e.AppendCompress(concatenated, part)
+
+	d := NewDecoder()
+	// Enough for one frame but not both.
+	if err := d.SetMaxSize(int64(len(part)) + 100); err != nil {
+		t.Fatal(err)
+	}
+	_, err := d.AppendDecompress(nil, concatenated)
+	var de *ErrDecodedSizeExceeded
+	if !errors.As(err, &de) {
+		t.Fatalf("expected cumulative ErrDecodedSizeExceeded, got %v", err)
+	}
+
+	// Enough for both frames succeeds.
+	if err := d.SetMaxSize(int64(2 * len(part))); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.AppendDecompress(nil, concatenated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := append(append([]byte{}, part...), part...)
+	if !bytes.Equal(got, want) {
+		t.Fatal("mismatch")
+	}
+}
+
+func TestDecoderReuseAcrossReaders(t *testing.T) {
+	e := NewEncoder()
+	uno := bytes.Repeat([]byte("uno "), 300)
+	dos := bytes.Repeat([]byte("dos "), 300)
+	f1 := e.AppendCompress(nil, uno)
+	f2 := e.AppendCompress(nil, dos)
+
+	d := NewDecoder()
+	for _, tc := range []struct{ frame, want []byte }{{f1, uno}, {f2, dos}} {
+		r := NewReader(bytes.NewReader(tc.frame), d)
+		got, err := io.ReadAll(r)
+		_ = r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, tc.want) {
+			t.Fatal("mismatch")
+		}
+	}
+}
+
+// TestDecoderReconfigureBetweenStreams tightens then loosens the max window on a
+// bound Decoder between Reset cycles and verifies the new limit is honored.
+func TestDecoderReconfigureBetweenStreams(t *testing.T) {
+	src := bytes.Repeat([]byte("decoder reconfigure "), 300)
+	compressed := NewEncoder().AppendCompress(nil, src)
+
+	d := NewDecoder()
+	r := NewReader(bytes.NewReader(compressed), d)
+
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch")
+	}
+
+	// Tighten the SAME decoder, reuse the SAME reader: must now fail.
+	if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
+		t.Fatal(err)
+	}
+	_, err = io.ReadAll(r)
+	var we *ErrWindowSizeExceeded
+	if !errors.As(err, &we) {
+		t.Fatalf("expected ErrWindowSizeExceeded after tightening, got %v", err)
+	}
+
+	// Loosen again: succeeds.
+	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Reset(bytes.NewReader(compressed)); err != nil {
+		t.Fatal(err)
+	}
+	got, err = io.ReadAll(r)
+	_ = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatal("mismatch")
 	}
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -59,7 +59,7 @@ func newXXHash(data []byte) uint64 {
 func TestReader_Read(t *testing.T) {
 	t.Run("raw_block", func(t *testing.T) {
 		frame := buildRawFrame([]byte("hello"))
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -80,7 +80,7 @@ func TestReader_Read(t *testing.T) {
 		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 		buf = append(buf, 'A') // repeated byte
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -108,7 +108,7 @@ func TestReader_Read(t *testing.T) {
 		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 		buf = append(buf, compData...)
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -135,7 +135,7 @@ func TestReader_Read(t *testing.T) {
 		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 		buf = append(buf, compData...)
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -162,7 +162,7 @@ func TestReader_Read(t *testing.T) {
 		buf = append(buf, byte(bh2), byte(bh2>>8), byte(bh2>>16))
 		buf = append(buf, 'd', 'e')
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -178,7 +178,7 @@ func TestReader_Read(t *testing.T) {
 		frame2 := buildRawFrame([]byte("lo"))
 		data := append(frame1, frame2...)
 
-		r := NewReader(bytes.NewReader(data), nil)
+		r := mustReader(t, bytes.NewReader(data))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -191,7 +191,7 @@ func TestReader_Read(t *testing.T) {
 
 	t.Run("checksum", func(t *testing.T) {
 		frame := buildRawFrameChecksum([]byte("abc"))
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -210,7 +210,7 @@ func TestReader_Read(t *testing.T) {
 		// Block: last=1, raw, size=0
 		buf = append(buf, 0x01, 0x00, 0x00)
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -231,7 +231,7 @@ func TestReader_Read(t *testing.T) {
 		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 		buf = append(buf, 'h', 'e', 'l', 'l', 'o')
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -255,7 +255,7 @@ func TestReader_Read(t *testing.T) {
 		bh := uint32(1) | (0 << 1) | (0 << 3)
 		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -268,7 +268,7 @@ func TestReader_Read(t *testing.T) {
 
 	t.Run("small_buffer", func(t *testing.T) {
 		frame := buildRawFrame([]byte("hello world"))
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer func() { _ = r.Close() }()
 
 		// Read one byte at a time
@@ -312,7 +312,7 @@ func (r *errReader) Read(p []byte) (int, error) {
 
 func TestReader_Read_Errors(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		r := NewReader(bytes.NewReader(nil), nil)
+		r := mustReader(t, bytes.NewReader(nil))
 		defer func() { _ = r.Close() }()
 		_, err := io.ReadAll(r)
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -327,7 +327,7 @@ func TestReader_Read_Errors(t *testing.T) {
 		frame := buildRawFrameChecksum([]byte("abc"))
 		// Corrupt the checksum (last 4 bytes)
 		frame[len(frame)-1] ^= 0xFF
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer func() { _ = r.Close() }()
 		_, err := io.ReadAll(r)
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -345,7 +345,7 @@ func TestReader_Read_Errors(t *testing.T) {
 		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 		buf = append(buf, 'a', 'b', 'c')
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		defer func() { _ = r.Close() }()
 		_, err := io.ReadAll(r)
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -354,7 +354,7 @@ func TestReader_Read_Errors(t *testing.T) {
 	})
 
 	t.Run("magic_mismatch", func(t *testing.T) {
-		r := NewReader(bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}), nil)
+		r := mustReader(t, bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}))
 		defer func() { _ = r.Close() }()
 		_, err := io.ReadAll(r)
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -370,7 +370,7 @@ func TestReader_Read_Errors(t *testing.T) {
 		buf = append(buf, 0x05)
 		buf = append(buf, 0x01, 0x00) // only 2 bytes of block header
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		_, err := io.ReadAll(r)
 		r.Close()
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -388,7 +388,7 @@ func TestReader_Read_Errors(t *testing.T) {
 		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 		buf = append(buf, 'a', 'b') // only 2 of 5 bytes
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		_, err := io.ReadAll(r)
 		r.Close()
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -405,7 +405,7 @@ func TestReader_Read_Errors(t *testing.T) {
 		bh := uint32(1) | (3 << 1) | (0 << 3)
 		buf = append(buf, byte(bh), byte(bh>>8), byte(bh>>16))
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		_, err := io.ReadAll(r)
 		r.Close()
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -419,7 +419,7 @@ func TestReader_Read_Errors(t *testing.T) {
 		// FHD with reserved bit 3 set.
 		buf = append(buf, 0x08)
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		_, err := io.ReadAll(r)
 		r.Close()
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -433,7 +433,7 @@ func TestReader_Read_Errors(t *testing.T) {
 		buf = append(buf, 0x01, 0x00, 0x00, 0x00)
 		buf = append(buf, 0xFF)
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		_, err := io.ReadAll(r)
 		r.Close()
 		if !errors.Is(err, &ErrCorrupted{}) {
@@ -447,7 +447,7 @@ func TestReader_Read_Errors(t *testing.T) {
 
 		// Truncate so the reader fails mid-block.
 		er := &errReader{data: frame[:len(frame)-5], err: readErr}
-		r := NewReader(er, nil)
+		r := mustReader(t, er)
 		_, err := io.ReadAll(r)
 		r.Close()
 		if err == nil {
@@ -472,7 +472,7 @@ func TestReader_Read_Skippable(t *testing.T) {
 		// Real frame
 		buf = append(buf, buildRawFrame([]byte("hi"))...)
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -492,7 +492,7 @@ func TestReader_Read_Skippable(t *testing.T) {
 		}
 		buf = append(buf, buildRawFrame([]byte("ok"))...)
 
-		r := NewReader(bytes.NewReader(buf), nil)
+		r := mustReader(t, bytes.NewReader(buf))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -510,7 +510,7 @@ func TestReader_Read_Skippable(t *testing.T) {
 			buf = append(buf, 0x00, 0x00, 0x00, 0x00) // 0 bytes to skip
 			buf = append(buf, buildRawFrame([]byte("x"))...)
 
-			r := NewReader(bytes.NewReader(buf), nil)
+			r := mustReader(t, bytes.NewReader(buf))
 			got, err := io.ReadAll(r)
 			r.Close()
 			if err != nil {
@@ -525,7 +525,7 @@ func TestReader_Read_Skippable(t *testing.T) {
 
 func TestReader_Read_AfterClose(t *testing.T) {
 	frame := buildRawFrame([]byte("test"))
-	r := NewReader(bytes.NewReader(frame), nil)
+	r := mustReader(t, bytes.NewReader(frame))
 	_ = r.Close()
 	_, err := r.Read(make([]byte, 10))
 	if err != ErrDecoderClosed {
@@ -536,7 +536,7 @@ func TestReader_Read_AfterClose(t *testing.T) {
 func TestReader_WriteTo(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		frame := buildRawFrame([]byte("hello"))
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer r.Close()
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
@@ -555,7 +555,7 @@ func TestReader_WriteTo(t *testing.T) {
 		frame = append(frame, 0x00)
 		frame = append(frame, 0x01, 0x00, 0x00)
 
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer r.Close()
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
@@ -579,7 +579,7 @@ func TestReader_WriteTo(t *testing.T) {
 		frame = append(frame, byte(bh2), byte(bh2>>8), byte(bh2>>16))
 		frame = append(frame, 'd', 'e')
 
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer r.Close()
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
@@ -593,7 +593,7 @@ func TestReader_WriteTo(t *testing.T) {
 
 	t.Run("multi_frame", func(t *testing.T) {
 		data := append(buildRawFrame([]byte("hi")), buildRawFrame([]byte("lo"))...)
-		r := NewReader(bytes.NewReader(data), nil)
+		r := mustReader(t, bytes.NewReader(data))
 		defer r.Close()
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
@@ -607,7 +607,7 @@ func TestReader_WriteTo(t *testing.T) {
 
 	t.Run("checksum", func(t *testing.T) {
 		frame := buildRawFrameChecksum([]byte("abc"))
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer r.Close()
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
@@ -623,13 +623,10 @@ func TestReader_WriteTo(t *testing.T) {
 		src := bytes.Repeat([]byte("compressed data for WriteTo test "), 100)
 		for level := BestSpeed; level <= BestCompression; level++ {
 			t.Run("", func(t *testing.T) {
-				e := NewEncoder()
-				if err := e.SetLevel(level); err != nil {
-					t.Fatal(err)
-				}
+				e := mustEncoder(t, WithEncoderLevel(level))
 				compressed := e.AppendCompress(nil, src)
 
-				r := NewReader(bytes.NewReader(compressed), nil)
+				r := mustReader(t, bytes.NewReader(compressed))
 				defer r.Close()
 				var buf bytes.Buffer
 				_, err := r.WriteTo(&buf)
@@ -650,11 +647,10 @@ func TestReader_WriteTo(t *testing.T) {
 			src[i] = byte(i % 251)
 		}
 		for level := BestSpeed; level <= BestCompression; level++ {
-			e := NewEncoder()
-			_ = e.SetLevel(level)
+			e := mustEncoder(t, WithEncoderLevel(level))
 			compressed := e.AppendCompress(nil, src)
 
-			r := NewReader(bytes.NewReader(compressed), nil)
+			r := mustReader(t, bytes.NewReader(compressed))
 			var buf bytes.Buffer
 			n, err := r.WriteTo(&buf)
 			r.Close()
@@ -675,10 +671,10 @@ func TestReader_WriteTo(t *testing.T) {
 		src := make([]byte, 1<<20)
 		rng.Read(src)
 
-		e := NewEncoder()
+		e := mustEncoder(t)
 		compressed := e.AppendCompress(nil, src)
 
-		r := NewReader(bytes.NewReader(compressed), nil)
+		r := mustReader(t, bytes.NewReader(compressed))
 		defer r.Close()
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
@@ -700,13 +696,10 @@ func TestReader_WriteTo(t *testing.T) {
 		src = bytes.Repeat(src, 10)
 
 		t.Run("raw", func(t *testing.T) {
-			e := NewEncoder()
-			e.SetRawDict(dictContent)
+			e := mustEncoder(t, WithEncoderRawDict(dictContent))
 			compressed := e.AppendCompress(nil, src)
 
-			dec := NewDecoder()
-			dec.SetRawDict(dictContent)
-			r := NewReader(bytes.NewReader(compressed), dec)
+			r := mustReader(t, bytes.NewReader(compressed), WithDecoderRawDict(dictContent))
 			defer r.Close()
 			var buf bytes.Buffer
 			_, err := r.WriteTo(&buf)
@@ -727,13 +720,10 @@ func TestReader_WriteTo(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			e := NewEncoder()
-			e.AddDict(d)
+			e := mustEncoder(t, WithEncoderDict(d))
 			compressed := e.AppendCompress(nil, src)
 
-			dec := NewDecoder()
-			dec.AddDict(d)
-			r := NewReader(bytes.NewReader(compressed), dec)
+			r := mustReader(t, bytes.NewReader(compressed), WithDecoderDict(d))
 			defer r.Close()
 			var buf bytes.Buffer
 			_, err = r.WriteTo(&buf)
@@ -755,7 +745,7 @@ func TestReader_WriteTo(t *testing.T) {
 		// Real frame
 		data = append(data, buildRawFrame([]byte("hi"))...)
 
-		r := NewReader(bytes.NewReader(data), nil)
+		r := mustReader(t, bytes.NewReader(data))
 		defer r.Close()
 		var buf bytes.Buffer
 		n, err := r.WriteTo(&buf)
@@ -774,11 +764,11 @@ func TestReader_WriteTo(t *testing.T) {
 			{},
 		}
 		for _, src := range inputs {
-			e := NewEncoder()
+			e := mustEncoder(t)
 			compressed := e.AppendCompress(nil, src)
 
 			// ReadAll
-			r1 := NewReader(bytes.NewReader(compressed), nil)
+			r1 := mustReader(t, bytes.NewReader(compressed))
 			readResult, err := io.ReadAll(r1)
 			r1.Close()
 			if err != nil {
@@ -786,7 +776,7 @@ func TestReader_WriteTo(t *testing.T) {
 			}
 
 			// WriteTo
-			r2 := NewReader(bytes.NewReader(compressed), nil)
+			r2 := mustReader(t, bytes.NewReader(compressed))
 			var buf bytes.Buffer
 			_, err = r2.WriteTo(&buf)
 			r2.Close()
@@ -802,7 +792,7 @@ func TestReader_WriteTo(t *testing.T) {
 
 	t.Run("after_partial_read", func(t *testing.T) {
 		frame := buildRawFrame([]byte("hello world"))
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer r.Close()
 
 		// Read only 5 bytes.
@@ -843,7 +833,7 @@ func (w *errWriter) Write(p []byte) (int, error) {
 
 func TestReader_WriteTo_Errors(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		r := NewReader(bytes.NewReader(nil), nil)
+		r := mustReader(t, bytes.NewReader(nil))
 		defer r.Close()
 		var buf bytes.Buffer
 		_, err := r.WriteTo(&buf)
@@ -858,7 +848,7 @@ func TestReader_WriteTo_Errors(t *testing.T) {
 	t.Run("bad_checksum", func(t *testing.T) {
 		frame := buildRawFrameChecksum([]byte("abc"))
 		frame[len(frame)-1] ^= 0xFF
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer r.Close()
 		var buf bytes.Buffer
 		_, err := r.WriteTo(&buf)
@@ -876,7 +866,7 @@ func TestReader_WriteTo_Errors(t *testing.T) {
 		frame = append(frame, byte(bh), byte(bh>>8), byte(bh>>16))
 		frame = append(frame, 'a', 'b', 'c') // only 3 bytes
 
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer r.Close()
 		var buf bytes.Buffer
 		_, err := r.WriteTo(&buf)
@@ -886,7 +876,7 @@ func TestReader_WriteTo_Errors(t *testing.T) {
 	})
 
 	t.Run("after_close", func(t *testing.T) {
-		r := NewReader(bytes.NewReader(buildRawFrame([]byte("test"))), nil)
+		r := mustReader(t, bytes.NewReader(buildRawFrame([]byte("test"))))
 		r.Close()
 		_, err := r.WriteTo(&bytes.Buffer{})
 		if err != ErrDecoderClosed {
@@ -896,7 +886,7 @@ func TestReader_WriteTo_Errors(t *testing.T) {
 
 	t.Run("write_error", func(t *testing.T) {
 		frame := buildRawFrame([]byte("hello world"))
-		r := NewReader(bytes.NewReader(frame), nil)
+		r := mustReader(t, bytes.NewReader(frame))
 		defer r.Close()
 
 		writeErr := errors.New("disk full")
@@ -915,11 +905,11 @@ func TestReader_WriteTo_Errors(t *testing.T) {
 
 	t.Run("partial_write_error", func(t *testing.T) {
 		src := bytes.Repeat([]byte("partial write test "), 500)
-		e := NewEncoder()
+		e := mustEncoder(t)
 		compressed := e.AppendCompress(nil, src)
 
 		writeErr := errors.New("out of space")
-		r := NewReader(bytes.NewReader(compressed), nil)
+		r := mustReader(t, bytes.NewReader(compressed))
 		// Accept 0 bytes — fail immediately.
 		ew := &errWriter{n: 0, err: writeErr}
 		_, err := r.WriteTo(ew)
@@ -935,7 +925,7 @@ func TestReader_Reset(t *testing.T) {
 		frame1 := buildRawFrame([]byte("first"))
 		frame2 := buildRawFrame([]byte("second"))
 
-		r := NewReader(bytes.NewReader(frame1), nil)
+		r := mustReader(t, bytes.NewReader(frame1))
 		defer func() { _ = r.Close() }()
 
 		got1, err := io.ReadAll(r)
@@ -959,7 +949,7 @@ func TestReader_Reset(t *testing.T) {
 	})
 
 	t.Run("nil_input", func(t *testing.T) {
-		r := NewReader(nil, nil)
+		r := mustReader(t, nil)
 		frame := buildRawFrame([]byte("after nil"))
 		if err := r.Reset(bytes.NewReader(frame)); err != nil {
 			t.Fatal(err)
@@ -975,7 +965,7 @@ func TestReader_Reset(t *testing.T) {
 	})
 
 	t.Run("nil_closes", func(t *testing.T) {
-		r := NewReader(bytes.NewReader(buildRawFrame([]byte("x"))), nil)
+		r := mustReader(t, bytes.NewReader(buildRawFrame([]byte("x"))))
 		if err := r.Reset(nil); err != nil {
 			t.Fatal(err)
 		}
@@ -989,7 +979,7 @@ func TestReader_Reset(t *testing.T) {
 		frame1 := buildRawFrame([]byte("before"))
 		frame2 := buildRawFrame([]byte("after"))
 
-		r := NewReader(bytes.NewReader(frame1), nil)
+		r := mustReader(t, bytes.NewReader(frame1))
 		got, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
@@ -1016,7 +1006,7 @@ func TestReader_Reset(t *testing.T) {
 		frame1 := buildRawFrame([]byte("before"))
 		frame2 := buildRawFrame([]byte("after"))
 
-		r := NewReader(bytes.NewReader(frame1), nil)
+		r := mustReader(t, bytes.NewReader(frame1))
 		got, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
@@ -1044,8 +1034,8 @@ func TestReader_Reset(t *testing.T) {
 		frame1 := buildRawFrame([]byte("before"))
 		frame2 := buildRawFrame([]byte("after"))
 
-		dec := NewDecoder()
-		r := NewReader(bytes.NewReader(frame1), dec)
+		dec := mustDecoder(t)
+		r := mustReader(t, bytes.NewReader(frame1))
 		got, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
@@ -1069,7 +1059,7 @@ func TestReader_Reset(t *testing.T) {
 	})
 
 	t.Run("reuse_multiple", func(t *testing.T) {
-		r := NewReader(bytes.NewReader(buildRawFrame([]byte("init"))), nil)
+		r := mustReader(t, bytes.NewReader(buildRawFrame([]byte("init"))))
 
 		for i := range 5 {
 			want := []byte{byte('A' + i), byte('0' + i)}
@@ -1125,18 +1115,14 @@ func TestReader_ZeroValue(t *testing.T) {
 	})
 }
 
-func TestSetMaxWindowSize(t *testing.T) {
+func TestReader_MaxWindowExceeded(t *testing.T) {
 	// Compress with default window (~4 MiB at level 3).
 	src := bytes.Repeat([]byte("window size test "), 200)
-	enc := NewEncoder()
+	enc := mustEncoder(t)
 	compressed := enc.AppendCompress(nil, src)
 
 	// Decoding with a tiny max window should fail.
-	d := NewDecoder()
-	if err := d.SetMaxWindowSize(MinWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	r := NewReader(bytes.NewReader(compressed), d)
+	r := mustReader(t, bytes.NewReader(compressed), WithDecoderMaxWindow(MinWindowSize))
 	_, err := io.ReadAll(r)
 	r.Close()
 	var e *ErrWindowSizeExceeded
@@ -1148,16 +1134,12 @@ func TestSetMaxWindowSize(t *testing.T) {
 	}
 }
 
-func TestSetMaxWindowSizeMax(t *testing.T) {
+func TestReader_MaxWindowAllowed(t *testing.T) {
 	src := bytes.Repeat([]byte("max window "), 200)
-	e := NewEncoder()
+	e := mustEncoder(t)
 	compressed := e.AppendCompress(nil, src)
 
-	d := NewDecoder()
-	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	r := NewReader(bytes.NewReader(compressed), d)
+	r := mustReader(t, bytes.NewReader(compressed), WithDecoderMaxWindow(MaxWindowSize))
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1168,12 +1150,12 @@ func TestSetMaxWindowSizeMax(t *testing.T) {
 	}
 }
 
-// TestSetMaxSizeStreamingRead covers the running per-block check on the streaming
+// TestWithDecoderMaxSizeStreamingRead covers the running per-block check on the streaming
 // Read path and its sticky-error behavior.
-func TestSetMaxSizeStreamingRead(t *testing.T) {
+func TestWithDecoderMaxSizeStreamingRead(t *testing.T) {
 	src := bytes.Repeat([]byte("streaming decode bomb guard "), 12000) // multi-block
 	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
+	w := mustWriter(t, &buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
 	}
@@ -1182,11 +1164,7 @@ func TestSetMaxSizeStreamingRead(t *testing.T) {
 	}
 	compressed := buf.Bytes()
 
-	d := NewDecoder()
-	if err := d.SetMaxSize(int64(len(src)) / 2); err != nil {
-		t.Fatal(err)
-	}
-	r := NewReader(bytes.NewReader(compressed), d)
+	r := mustReader(t, bytes.NewReader(compressed), WithDecoderMaxSize(int64(len(src))/2))
 	_, err := io.ReadAll(r)
 	var de *ErrDecodedSizeExceeded
 	if !errors.As(err, &de) {
@@ -1198,11 +1176,8 @@ func TestSetMaxSizeStreamingRead(t *testing.T) {
 	}
 	_ = r.Close()
 
-	// Raising the limit on the same decoder and resetting the reader succeeds.
-	if err := d.SetMaxSize(int64(len(src))); err != nil {
-		t.Fatal(err)
-	}
-	r = NewReader(bytes.NewReader(compressed), d)
+	// A fresh reader with a higher limit succeeds.
+	r = mustReader(t, bytes.NewReader(compressed), WithDecoderMaxSize(int64(len(src))))
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -1213,17 +1188,13 @@ func TestSetMaxSizeStreamingRead(t *testing.T) {
 	}
 }
 
-// TestSetMaxSizeWriteToNoFlush verifies an over-limit frame produces no output
+// TestWithDecoderMaxSizeWriteToNoFlush verifies an over-limit frame produces no output
 // through WriteTo (the guard runs before the block is written).
-func TestSetMaxSizeWriteToNoFlush(t *testing.T) {
+func TestWithDecoderMaxSizeWriteToNoFlush(t *testing.T) {
 	src := bytes.Repeat([]byte("x"), 4000)
-	compressed := NewEncoder().AppendCompress(nil, src)
+	compressed := mustEncoder(t).AppendCompress(nil, src)
 
-	d := NewDecoder()
-	if err := d.SetMaxSize(int64(len(src)) - 1); err != nil {
-		t.Fatal(err)
-	}
-	r := NewReader(bytes.NewReader(compressed), d)
+	r := mustReader(t, bytes.NewReader(compressed), WithDecoderMaxSize(int64(len(src))-1))
 	var out bytes.Buffer
 	n, err := r.WriteTo(&out)
 	_ = r.Close()

--- a/reader_test.go
+++ b/reader_test.go
@@ -1078,6 +1078,38 @@ func TestReader_Reset(t *testing.T) {
 			r.Close()
 		}
 	})
+
+	t.Run("change_max_size", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("x"), 4096)
+		frame := mustEncoder(t).AppendCompress(nil, payload)
+
+		// A small limit rejects the stream.
+		r := mustReader(t, bytes.NewReader(frame), WithDecoderMaxSize(100))
+		defer func() { _ = r.Close() }()
+		var de *ErrDecodedSizeExceeded
+		if _, err := io.ReadAll(r); !errors.As(err, &de) {
+			t.Fatalf("expected ErrDecodedSizeExceeded, got %v", err)
+		}
+
+		// Resetting with a larger limit accepts the same stream.
+		if err := r.Reset(bytes.NewReader(frame), WithDecoderMaxSize(int64(len(payload)))); err != nil {
+			t.Fatal(err)
+		}
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("invalid_option", func(t *testing.T) {
+		r := mustReader(t, nil)
+		if err := r.Reset(bytes.NewReader(nil), WithDecoderMaxSize(-1)); err == nil {
+			t.Fatal("expected error for negative max size")
+		}
+	})
 }
 
 func TestReader_ZeroValue(t *testing.T) {

--- a/writer.go
+++ b/writer.go
@@ -49,26 +49,23 @@ func NewWriter(w io.Writer, opts ...EncoderOption) (*Writer, error) {
 	}
 	wr := &Writer{cfg: e}
 	if w != nil {
-		wr.Reset(w)
+		if err := wr.Reset(w); err != nil {
+			return nil, err
+		}
 	}
 	return wr, nil
 }
 
-// ResetContentSize resets the Writer for a new stream to wr and records
-// the uncompressed content size in the frame header. If size is negative
-// the content size is omitted.
-func (w *Writer) ResetContentSize(wr io.Writer, size int64) {
+// Reset discards the Writer's state and prepares it to write a new frame to wr.
+// Options in opts are applied to the configuration first; any option may be
+// changed. With no options the current configuration is preserved.
+func (w *Writer) Reset(wr io.Writer, opts ...EncoderOption) error {
 	w.ensureInit()
-	w.Reset(wr)
-	if size >= 0 {
-		w.contentSize = size
+	for _, o := range opts {
+		if err := o(w.cfg); err != nil {
+			return err
+		}
 	}
-}
-
-// Reset discards the Writer's state and prepares it to write a new frame
-// to wr. Configuration is preserved.
-func (w *Writer) Reset(wr io.Writer) {
-	w.ensureInit()
 	if cap(w.filling) == 0 {
 		w.filling = make([]byte, 0, w.cfg.blockSize)
 	}
@@ -87,7 +84,8 @@ func (w *Writer) Reset(wr io.Writer) {
 	w.err = nil
 	w.nWritten = 0
 	w.nInput = 0
-	w.contentSize = 0
+	w.contentSize = w.cfg.contentSize
+	return nil
 }
 
 // Write compresses p and writes it to the underlying writer.

--- a/writer.go
+++ b/writer.go
@@ -7,69 +7,19 @@ package zstd
 import (
 	"fmt"
 	"io"
-	"math"
-	"sync"
 )
 
 var _ io.ReaderFrom = (*Writer)(nil)
-
-// Compression level constants. These map to the levels accepted by
-// [Writer.SetLevel].
-const (
-	DefaultCompression = -1 // level 3
-	NoCompression      = 0  // store blocks without compression
-	BestSpeed          = 1  // lowest compression, fastest speed
-	BestCompression    = 9  // highest compression, slowest speed
-)
-
-// encoderPools caches encoders by category to avoid repeated hash table allocation.
-var encoderPools [5]sync.Pool
-
-// putEncoder returns an encoder to its pool for reuse.
-func putEncoder(enc encoder) {
-	switch enc.(type) {
-	case *rawEncoder:
-		encoderPools[0].Put(enc)
-	case *fastEncoder:
-		encoderPools[1].Put(enc)
-	case *doubleFastEncoder:
-		encoderPools[2].Put(enc)
-	case *betterFastEncoder:
-		encoderPools[3].Put(enc)
-	case *bestFastEncoder:
-		encoderPools[4].Put(enc)
-	}
-}
-
-// encoderCategory maps a compression level to a pool index (0-4).
-func encoderCategory(level int) int {
-	switch {
-	case level == 0:
-		return 0
-	case level <= 2:
-		return 1
-	case level <= 4:
-		return 2
-	case level <= 7:
-		return 3
-	default:
-		return 4
-	}
-}
 
 // Writer compresses data written to it as a zstd stream.
 // Writes are buffered internally; callers must call [Writer.Close] to
 // flush any remaining data and write the frame trailer.
 type Writer struct {
+	cfg *Encoder
 	w   io.Writer
 	enc encoder
 
 	filling []byte
-
-	blockSize int
-	wndSize   int
-	level     int
-	crc       bool
 
 	headerWritten    bool
 	eofWritten       bool
@@ -78,128 +28,30 @@ type Writer struct {
 	nWritten         int64
 	nInput           int64
 	contentSize      int64
-	lowMem           bool
-
-	dict        *dict
-	initialized bool
 }
 
 // ensureInit lazily initializes the Writer on first use.
 func (w *Writer) ensureInit() {
-	if w.initialized {
-		return
+	if w.cfg == nil {
+		w.cfg = NewEncoder()
 	}
-	w.initialized = true
-	initPredefined()
-	w.level = 3
-	w.blockSize = maxCompressedBlockSize
-	w.wndSize = 4 << 20
-	w.crc = true
+	w.cfg.ensureInit()
 }
 
-// NewWriter returns a new Writer compressing data at the default level.
-// If w is nil the Writer may only be used with [Writer.AppendCompress];
-// call [Writer.Reset] before streaming.
-func NewWriter(w io.Writer) *Writer {
-	wr := &Writer{}
-	wr.ensureInit()
+// NewWriter returns a new Writer that compresses data written to w using the
+// configuration held by e. If e is nil, default configuration is used.
+// If w is nil the Writer must be pointed at a destination with [Writer.Reset]
+// before streaming.
+func NewWriter(w io.Writer, e *Encoder) *Writer {
+	if e == nil {
+		e = NewEncoder()
+	}
+	e.ensureInit()
+	wr := &Writer{cfg: e}
 	if w != nil {
 		wr.Reset(w)
 	}
 	return wr
-}
-
-// SetLevel sets the compression level. Valid values range from
-// [NoCompression] (0) to [BestCompression] (9); [DefaultCompression] (-1)
-// selects level 3. SetLevel must be called before [Writer.Reset] or
-// [Writer.Write] to take effect.
-func (w *Writer) SetLevel(level int) error {
-	w.ensureInit()
-	if level == DefaultCompression {
-		level = 3
-	}
-	if level < NoCompression || level > BestCompression {
-		return fmt.Errorf("zstd: invalid level %d", level)
-	}
-	w.level = level
-	w.blockSize = maxCompressedBlockSize
-	// These mirror zstd default window sizes at levels 1, 3 and 9.
-	switch level {
-	case 0:
-		w.wndSize = 0
-	case 1:
-		w.wndSize = 2 << 20
-	case 2:
-		w.wndSize = 3 << 20
-	case 3:
-		w.wndSize = 4 << 20
-	case 4:
-		w.wndSize = 4 << 20
-	case 5:
-		w.wndSize = 4 << 20
-	case 6:
-		w.wndSize = 5 << 20
-	case 7:
-		w.wndSize = 6 << 20
-	case 8:
-		w.wndSize = 7 << 20
-	case 9:
-		w.wndSize = 8 << 20
-	}
-	return nil
-}
-
-// SetWindowSize overrides the window size for compression.
-// This allows limiting memory usage both for compression and decompression.
-//
-// n must be in the range [MinWindowSize, MaxWindowSize].
-func (w *Writer) SetWindowSize(n int) error {
-	w.ensureInit()
-	if n < MinWindowSize || n > MaxWindowSize {
-		return fmt.Errorf("zstd: window size %d out of range [%d, %d]", n, MinWindowSize, MaxWindowSize)
-	}
-	w.wndSize = n
-	return nil
-}
-
-// SetLowMemory controls whether the encoder should trade speed for
-// lower memory usage.
-func (w *Writer) SetLowMemory(b bool) {
-	w.ensureInit()
-	w.lowMem = b
-}
-
-// SetCRC controls whether the writer appends a xxHash-64 checksum to each
-// frame. The default is true.
-func (w *Writer) SetCRC(b bool) {
-	w.ensureInit()
-	w.crc = b
-}
-
-// AddDict registers a parsed dictionary for compression.
-// Passing nil removes the previous dictionary.
-func (w *Writer) AddDict(d *Dict) {
-	w.ensureInit()
-	if d == nil {
-		w.dict = nil
-		return
-	}
-	w.dict = d.d
-}
-
-// SetRawDict registers raw bytes as a dictionary prefix.
-// The dictionary must be at least 8 bytes; shorter non-nil values are ignored.
-// Passing nil removes any previous dictionary.
-func (w *Writer) SetRawDict(b []byte) {
-	w.ensureInit()
-	if b == nil {
-		w.dict = nil
-		return
-	}
-	if len(b) < 8 {
-		return
-	}
-	w.dict = &dict{content: b}
 }
 
 // ResetContentSize resets the Writer for a new stream to wr and records
@@ -218,15 +70,15 @@ func (w *Writer) ResetContentSize(wr io.Writer, size int64) {
 func (w *Writer) Reset(wr io.Writer) {
 	w.ensureInit()
 	if cap(w.filling) == 0 {
-		w.filling = make([]byte, 0, w.blockSize)
+		w.filling = make([]byte, 0, w.cfg.blockSize)
 	}
 	w.filling = w.filling[:0]
 
 	if w.enc != nil {
 		putEncoder(w.enc)
 	}
-	w.enc = w.newEncoder()
-	w.enc.reset(w.dict, false)
+	w.enc = w.cfg.newEncoder()
+	w.enc.reset(w.cfg.dict, false)
 
 	w.w = wr
 	w.headerWritten = false
@@ -238,46 +90,6 @@ func (w *Writer) Reset(wr io.Writer) {
 	w.contentSize = 0
 }
 
-// newEncoder creates the appropriate encoder for the current level,
-// pulling from a pool when possible to avoid hash table allocation.
-func (w *Writer) newEncoder() encoder {
-	maxOff := int32(w.wndSize)
-	if maxOff == 0 {
-		maxOff = 4 << 20
-	}
-	bufReset := math.MaxInt32 - maxOff*2
-	cat := encoderCategory(w.level)
-
-	if v := encoderPools[cat].Get(); v != nil {
-		enc := v.(encoder)
-		enc.configure(maxOff, bufReset, w.lowMem)
-		return enc
-	}
-
-	switch {
-	case w.level == 0:
-		e := &rawEncoder{}
-		e.configure(maxOff, bufReset, w.lowMem)
-		return e
-	case w.level <= 2:
-		e := &fastEncoder{}
-		e.configure(maxOff, bufReset, w.lowMem)
-		return e
-	case w.level <= 4:
-		e := &doubleFastEncoder{}
-		e.configure(maxOff, bufReset, w.lowMem)
-		return e
-	case w.level <= 7:
-		e := &betterFastEncoder{}
-		e.configure(maxOff, bufReset, w.lowMem)
-		return e
-	default:
-		e := &bestFastEncoder{}
-		e.configure(maxOff, bufReset, w.lowMem)
-		return e
-	}
-}
-
 // Write compresses p and writes it to the underlying writer.
 // The compressed bytes are not necessarily flushed until [Writer.Close]
 // or [Writer.Flush] is called.
@@ -287,24 +99,24 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 		return 0, ErrEncoderClosed
 	}
 	for len(p) > 0 {
-		if len(p)+len(w.filling) < w.blockSize {
-			if w.crc {
+		if len(p)+len(w.filling) < w.cfg.blockSize {
+			if w.cfg.crc {
 				_, _ = w.enc.checksum().Write(p)
 			}
 			w.filling = append(w.filling, p...)
 			return n + len(p), nil
 		}
 		add := p
-		if len(p)+len(w.filling) > w.blockSize {
-			add = add[:w.blockSize-len(w.filling)]
+		if len(p)+len(w.filling) > w.cfg.blockSize {
+			add = add[:w.cfg.blockSize-len(w.filling)]
 		}
-		if w.crc {
+		if w.cfg.crc {
 			_, _ = w.enc.checksum().Write(add)
 		}
 		w.filling = append(w.filling, add...)
 		p = p[len(add):]
 		n += len(add)
-		if len(w.filling) < w.blockSize {
+		if len(w.filling) < w.cfg.blockSize {
 			return n, nil
 		}
 		if err := w.nextBlock(false); err != nil {
@@ -323,11 +135,11 @@ func (w *Writer) ReadFrom(r io.Reader) (n int64, err error) {
 			return 0, err
 		}
 	}
-	w.filling = w.filling[:w.blockSize]
+	w.filling = w.filling[:w.cfg.blockSize]
 	src := w.filling
 	for {
 		n2, err := r.Read(src)
-		if w.crc {
+		if w.cfg.crc {
 			_, _ = w.enc.checksum().Write(src[:n2])
 		}
 		src = src[n2:]
@@ -347,7 +159,7 @@ func (w *Writer) ReadFrom(r io.Reader) (n int64, err error) {
 		if err = w.nextBlock(false); err != nil {
 			return n, err
 		}
-		w.filling = w.filling[:w.blockSize]
+		w.filling = w.filling[:w.cfg.blockSize]
 		src = w.filling
 	}
 }
@@ -388,7 +200,7 @@ func (w *Writer) Close() error {
 		return w.err
 	}
 
-	if w.crc {
+	if w.cfg.crc {
 		var tmp [4]byte
 		_, w.err = w.w.Write(w.enc.appendCRC(tmp[:0]))
 		w.nWritten += 4
@@ -400,44 +212,18 @@ func (w *Writer) Close() error {
 	return w.err
 }
 
-// AppendCompress compresses src as a single zstd frame and appends the result to dst,
-// returning the extended buffer. It is a one-shot alternative to the streaming
-// Write/Close interface.
-//
-// The Writer's current level, dictionary, CRC, and window-size settings apply.
-// The returned frame is self-contained: it includes a frame header, one or more
-// blocks, and an optional checksum.
-//
-// Passing nil for dst allocates a new slice. Passing a non-nil dst (e.g. buf[:0])
-// lets the caller reuse memory. Multiple calls may be made to concatenate frames:
-//
-//	var frames []byte
-//	frames = w.AppendCompress(part1, frames)
-//	frames = w.AppendCompress(part2, frames)
-//
-// If src is nil or empty, a minimal valid frame is appended to dst.
-//
-// AppendCompress is safe for concurrent use on the same Writer,
-// provided configuration methods are not called concurrently.
-func (w *Writer) AppendCompress(dst, src []byte) []byte {
-	w.ensureInit()
-	enc := w.newEncoder()
-	defer putEncoder(enc)
-	return w.encodeAll(enc, src, dst)
-}
-
 // nextBlock encodes the current filling buffer as a block.
 func (w *Writer) nextBlock(final bool) error {
 	if w.err != nil {
 		return w.err
 	}
-	if len(w.filling) > w.blockSize {
+	if len(w.filling) > w.cfg.blockSize {
 		return fmt.Errorf("block > maxStoreBlockSize")
 	}
 	if !w.headerWritten {
 		if final {
 			var current []byte
-			current = w.encodeAll(w.enc, w.filling, current)
+			current = w.cfg.encodeAll(w.enc, w.filling, current)
 			var n2 int
 			n2, w.err = w.w.Write(current)
 			if w.err != nil {
@@ -457,8 +243,8 @@ func (w *Writer) nextBlock(final bool) error {
 			ContentSize:   uint64(w.contentSize),
 			WindowSize:    uint32(w.enc.windowSize(w.contentSize)),
 			SingleSegment: false,
-			Checksum:      w.crc,
-			DictID:        w.dict.ID(),
+			Checksum:      w.cfg.crc,
+			DictID:        w.cfg.dict.ID(),
 		}
 		dst := fh.appendTo(tmp[:0])
 		w.headerWritten = true
@@ -524,107 +310,4 @@ func (w *Writer) nextBlock(final bool) error {
 	w.nWritten += int64(len(blk.output))
 	w.filling = w.filling[:0]
 	return w.err
-}
-
-// encodeAll compresses src into a single frame appended to dst.
-func (w *Writer) encodeAll(enc encoder, src, dst []byte) []byte {
-	if len(src) == 0 {
-		fh := frameHeader{
-			ContentSize:   0,
-			WindowSize:    MinWindowSize,
-			SingleSegment: true,
-			Checksum:      w.crc,
-			DictID:        w.dict.ID(),
-		}
-		dst = fh.appendTo(dst)
-		var blk blockHeader
-		blk.setSize(0)
-		blk.setType(blockTypeRaw)
-		blk.setLast(true)
-		dst = blk.appendTo(dst)
-		if w.crc {
-			enc.reset(nil, true)
-			dst = enc.appendCRC(dst)
-		}
-		return dst
-	}
-
-	single := len(src) <= w.wndSize && len(src) > MinWindowSize
-	fh := frameHeader{
-		ContentSize:   uint64(len(src)),
-		WindowSize:    uint32(enc.windowSize(int64(len(src)))),
-		SingleSegment: single,
-		Checksum:      w.crc,
-		DictID:        w.dict.ID(),
-	}
-
-	if len(dst) == 0 && cap(dst) == 0 && len(src) < 1<<20 {
-		dst = make([]byte, 0, len(src))
-	}
-	dst = fh.appendTo(dst)
-
-	if raw, ok := enc.(rawBlockWriter); ok {
-		enc.reset(nil, true)
-		if w.crc {
-			_, _ = enc.checksum().Write(src)
-		}
-		for len(src) > 0 {
-			todo := src
-			if len(todo) > maxCompressedBlockSize {
-				todo = todo[:maxCompressedBlockSize]
-			}
-			src = src[len(todo):]
-			dst = raw.appendRaw(dst, todo, len(src) == 0)
-		}
-	} else if len(src) <= w.blockSize {
-		enc.reset(w.dict, true)
-		if w.crc {
-			_, _ = enc.checksum().Write(src)
-		}
-		blk := enc.block()
-		blk.last = true
-		if w.dict == nil {
-			enc.encodeNoHist(blk, src)
-		} else {
-			enc.encode(blk, src)
-		}
-
-		oldout := blk.output
-		blk.output = dst
-
-		err := blk.encode(src, false, true)
-		if err != nil {
-			panic(err)
-		}
-		dst = blk.output
-		blk.output = oldout
-	} else {
-		enc.reset(w.dict, false)
-		blk := enc.block()
-		for len(src) > 0 {
-			todo := src
-			if len(todo) > w.blockSize {
-				todo = todo[:w.blockSize]
-			}
-			src = src[len(todo):]
-			if w.crc {
-				_, _ = enc.checksum().Write(todo)
-			}
-			blk.pushOffsets()
-			enc.encode(blk, todo)
-			if len(src) == 0 {
-				blk.last = true
-			}
-			err := blk.encode(todo, false, true)
-			if err != nil {
-				panic(err)
-			}
-			dst = append(dst, blk.output...)
-			blk.reset(nil)
-		}
-	}
-	if w.crc {
-		dst = enc.appendCRC(dst)
-	}
-	return dst
 }

--- a/writer.go
+++ b/writer.go
@@ -33,25 +33,25 @@ type Writer struct {
 // ensureInit lazily initializes the Writer on first use.
 func (w *Writer) ensureInit() {
 	if w.cfg == nil {
-		w.cfg = NewEncoder()
+		w.cfg = &Encoder{}
 	}
 	w.cfg.ensureInit()
 }
 
 // NewWriter returns a new Writer that compresses data written to w using the
-// configuration held by e. If e is nil, default configuration is used.
+// configuration built from opts. With no options, default configuration is used.
 // If w is nil the Writer must be pointed at a destination with [Writer.Reset]
 // before streaming.
-func NewWriter(w io.Writer, e *Encoder) *Writer {
-	if e == nil {
-		e = NewEncoder()
+func NewWriter(w io.Writer, opts ...EncoderOption) (*Writer, error) {
+	e, err := NewEncoder(opts...)
+	if err != nil {
+		return nil, err
 	}
-	e.ensureInit()
 	wr := &Writer{cfg: e}
 	if w != nil {
 		wr.Reset(w)
 	}
-	return wr
+	return wr, nil
 }
 
 // ResetContentSize resets the Writer for a new stream to wr and records

--- a/writer_test.go
+++ b/writer_test.go
@@ -16,7 +16,7 @@ import (
 func roundTrip(t *testing.T, src []byte) {
 	t.Helper()
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	_, err := w.Write(src)
 	if err != nil {
 		t.Fatal("write:", err)
@@ -25,7 +25,7 @@ func roundTrip(t *testing.T, src []byte) {
 		t.Fatal("close:", err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -38,14 +38,14 @@ func roundTrip(t *testing.T, src []byte) {
 
 func TestWriterEmpty(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
 	if buf.Len() == 0 {
 		t.Fatal("expected non-empty frame for empty input")
 	}
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -114,7 +114,7 @@ func TestWriterMultipleSmallWrites(t *testing.T) {
 	src = bytes.Repeat(src, 100)
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	for i := 0; i < len(src); i += 7 {
 		end := min(i+7, len(src))
 		_, err := w.Write(src[i:end])
@@ -126,7 +126,7 @@ func TestWriterMultipleSmallWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -139,7 +139,7 @@ func TestWriterMultipleSmallWrites(t *testing.T) {
 
 func TestWriterFlush(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	part1 := []byte("first part of data. ")
 	part2 := []byte("second part of data.")
 
@@ -163,7 +163,7 @@ func TestWriterFlush(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -180,7 +180,7 @@ func TestWriterReset(t *testing.T) {
 	src2 := []byte("second stream content after reset")
 
 	var buf1, buf2 bytes.Buffer
-	w := NewWriter(&buf1)
+	w := NewWriter(&buf1, nil)
 	_, _ = w.Write(src1)
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
@@ -200,7 +200,7 @@ func TestWriterReset(t *testing.T) {
 		{buf1.Bytes(), src1},
 		{buf2.Bytes(), src2},
 	} {
-		r := NewReader(bytes.NewReader(tc.compressed))
+		r := NewReader(bytes.NewReader(tc.compressed), nil)
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -214,7 +214,7 @@ func TestWriterReset(t *testing.T) {
 
 func TestWriterWriteAfterClose(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	_, _ = w.Write([]byte("data"))
 	_ = w.Close()
 
@@ -226,7 +226,7 @@ func TestWriterWriteAfterClose(t *testing.T) {
 
 func TestWriterDoubleClose(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	_, _ = w.Write([]byte("data"))
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
@@ -238,23 +238,23 @@ func TestWriterDoubleClose(t *testing.T) {
 }
 
 func TestWriterSetLevel(t *testing.T) {
-	w := NewWriter(nil)
-	if err := w.SetLevel(DefaultCompression); err != nil {
+	e := NewEncoder()
+	if err := e.SetLevel(DefaultCompression); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.SetLevel(NoCompression); err != nil {
+	if err := e.SetLevel(NoCompression); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.SetLevel(BestSpeed); err != nil {
+	if err := e.SetLevel(BestSpeed); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.SetLevel(BestCompression); err != nil {
+	if err := e.SetLevel(BestCompression); err != nil {
 		t.Fatal(err)
 	}
-	if err := w.SetLevel(10); err == nil {
+	if err := e.SetLevel(10); err == nil {
 		t.Fatal("expected error for invalid level")
 	}
-	if err := w.SetLevel(-2); err == nil {
+	if err := e.SetLevel(-2); err == nil {
 		t.Fatal("expected error for invalid level")
 	}
 }
@@ -262,10 +262,11 @@ func TestWriterSetLevel(t *testing.T) {
 func TestNoCompressionIsRaw(t *testing.T) {
 	src := bytes.Repeat([]byte("hello world! this is highly compressible data. "), 1000)
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
-	if err := w.SetLevel(NoCompression); err != nil {
+	e := NewEncoder()
+	if err := e.SetLevel(NoCompression); err != nil {
 		t.Fatal(err)
 	}
+	w := NewWriter(&buf, e)
 	w.Reset(&buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
@@ -276,7 +277,7 @@ func TestNoCompressionIsRaw(t *testing.T) {
 	if buf.Len() < len(src) {
 		t.Errorf("NoCompression reduced size: src=%d compressed=%d", len(src), buf.Len())
 	}
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -288,15 +289,15 @@ func TestNoCompressionIsRaw(t *testing.T) {
 
 	// Also test AppendCompress path.
 	buf.Reset()
-	w2 := NewWriter(nil)
-	if err := w2.SetLevel(NoCompression); err != nil {
+	e2 := NewEncoder()
+	if err := e2.SetLevel(NoCompression); err != nil {
 		t.Fatal(err)
 	}
-	compressed := w2.AppendCompress(nil, src)
+	compressed := e2.AppendCompress(nil, src)
 	if len(compressed) < len(src) {
 		t.Errorf("AppendCompress NoCompression reduced size: src=%d compressed=%d", len(src), len(compressed))
 	}
-	r2 := NewReader(bytes.NewReader(compressed))
+	r2 := NewReader(bytes.NewReader(compressed), nil)
 	defer r2.Close()
 	got2, err := io.ReadAll(r2)
 	if err != nil {
@@ -309,10 +310,10 @@ func TestNoCompressionIsRaw(t *testing.T) {
 
 func TestWriterAppendCompress(t *testing.T) {
 	src := bytes.Repeat([]byte("encode all test data! "), 500)
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -324,16 +325,16 @@ func TestWriterAppendCompress(t *testing.T) {
 }
 
 func TestWriterAppendCompressEmpty(t *testing.T) {
-	w := NewWriter(nil)
-	c1 := w.AppendCompress(nil, nil)
-	c2 := w.AppendCompress(nil, []byte{})
+	e := NewEncoder()
+	c1 := e.AppendCompress(nil, nil)
+	c2 := e.AppendCompress(nil, []byte{})
 	if len(c1) == 0 {
 		t.Fatal("expected non-empty frame for nil input")
 	}
 	if !bytes.Equal(c1, c2) {
 		t.Fatal("nil and empty should produce identical frames")
 	}
-	r := NewReader(bytes.NewReader(c1))
+	r := NewReader(bytes.NewReader(c1), nil)
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -349,10 +350,10 @@ func TestWriterAppendCompressMultiBlock(t *testing.T) {
 	for i := range src {
 		src[i] = byte(i % 200)
 	}
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -367,7 +368,7 @@ func TestWriterReadFrom(t *testing.T) {
 	src := bytes.Repeat([]byte("ReadFrom test data! "), 1000)
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	n, err := w.ReadFrom(bytes.NewReader(src))
 	if err != nil {
 		t.Fatal(err)
@@ -379,7 +380,7 @@ func TestWriterReadFrom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -393,14 +394,14 @@ func TestWriterReadFrom(t *testing.T) {
 func TestWriterCRCEnabled(t *testing.T) {
 	src := []byte("checksum test data")
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	_, _ = w.Write(src)
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify readable (CRC checked by reader).
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -414,15 +415,16 @@ func TestWriterCRCEnabled(t *testing.T) {
 func TestWriterNoCRC(t *testing.T) {
 	src := []byte("no checksum test data, slightly longer to be interesting")
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
-	w.SetCRC(false)
+	e := NewEncoder()
+	e.SetCRC(false)
+	w := NewWriter(&buf, e)
 	w.Reset(&buf)
 	_, _ = w.Write(src)
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -436,7 +438,7 @@ func TestWriterNoCRC(t *testing.T) {
 func TestWriterWriteCountCorrect(t *testing.T) {
 	src := []byte("verify write count returns correct values")
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 
 	n, err := w.Write(src[:10])
 	if err != nil || n != 10 {
@@ -455,7 +457,7 @@ func TestWriterSingleByteWrites(t *testing.T) {
 	src := []byte("byte by byte writing test, long enough to have content")
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	for _, b := range src {
 		_, err := w.Write([]byte{b})
 		if err != nil {
@@ -466,7 +468,7 @@ func TestWriterSingleByteWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -481,7 +483,7 @@ func TestWriterSmallBuffer(t *testing.T) {
 	src := bytes.Repeat([]byte("small buffer read test "), 200)
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
 	}
@@ -489,7 +491,7 @@ func TestWriterSmallBuffer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 
 	// Read in small chunks.
@@ -513,10 +515,11 @@ func TestWriterSmallBuffer(t *testing.T) {
 func roundTripLevel(t *testing.T, src []byte, level int) {
 	t.Helper()
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
-	if err := w.SetLevel(level); err != nil {
+	e := NewEncoder()
+	if err := e.SetLevel(level); err != nil {
 		t.Fatal(err)
 	}
+	w := NewWriter(&buf, e)
 	w.Reset(&buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal("write:", err)
@@ -525,7 +528,7 @@ func roundTripLevel(t *testing.T, src []byte, level int) {
 		t.Fatal("close:", err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -617,12 +620,12 @@ func TestAppendCompressAllLevels(t *testing.T) {
 	src := bytes.Repeat([]byte("AppendCompress test data across levels! "), 500)
 	for level := 1; level <= BestCompression; level++ {
 		t.Run("", func(t *testing.T) {
-			w := NewWriter(nil)
-			if err := w.SetLevel(level); err != nil {
+			e := NewEncoder()
+			if err := e.SetLevel(level); err != nil {
 				t.Fatal(err)
 			}
-			compressed := w.AppendCompress(nil, src)
-			r := NewReader(bytes.NewReader(compressed))
+			compressed := e.AppendCompress(nil, src)
+			r := NewReader(bytes.NewReader(compressed), nil)
 			defer func() { _ = r.Close() }()
 			got, err := io.ReadAll(r)
 			if err != nil {
@@ -637,17 +640,18 @@ func TestAppendCompressAllLevels(t *testing.T) {
 
 func TestLevelSwitching(t *testing.T) {
 	src := bytes.Repeat([]byte("level switching test "), 200)
-	w := NewWriter(nil)
+	e := NewEncoder()
+	w := NewWriter(nil, e)
 	for level := 1; level <= BestCompression; level++ {
 		var buf bytes.Buffer
-		_ = w.SetLevel(level)
+		_ = e.SetLevel(level)
 		w.Reset(&buf)
 		_, _ = w.Write(src)
 		if err := w.Close(); err != nil {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()))
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -661,10 +665,10 @@ func TestLevelSwitching(t *testing.T) {
 
 func TestZeroValueWriter(t *testing.T) {
 	src := bytes.Repeat([]byte("zero value writer "), 100)
-	var w Writer
-	compressed := w.AppendCompress(nil, src)
+	var e Encoder
+	compressed := e.AppendCompress(nil, src)
 
-	r := NewReader(bytes.NewReader(compressed))
+	r := NewReader(bytes.NewReader(compressed), nil)
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -687,7 +691,7 @@ func TestZeroValueWriterStream(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	defer r.Close()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -700,12 +704,12 @@ func TestZeroValueWriterStream(t *testing.T) {
 
 func TestZeroValueWriterConfig(t *testing.T) {
 	src := bytes.Repeat([]byte("zero config "), 100)
-	var w Writer
-	w.SetCRC(false)
-	compressed := w.AppendCompress(nil, src)
+	var e Encoder
+	e.SetCRC(false)
+	compressed := e.AppendCompress(nil, src)
 
-	var r Reader
-	got, err := r.AppendDecompress(nil, compressed)
+	var d Decoder
+	got, err := d.AppendDecompress(nil, compressed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -714,111 +718,10 @@ func TestZeroValueWriterConfig(t *testing.T) {
 	}
 }
 
-func TestAppendCompressConcurrent(t *testing.T) {
-	src := bytes.Repeat([]byte("concurrent compress test data! "), 500)
-	w := NewWriter(nil)
-
-	const goroutines = 8
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	errs := make(chan error, goroutines)
-
-	for range goroutines {
-		go func() {
-			defer wg.Done()
-			compressed := w.AppendCompress(nil, src)
-			r := NewReader(bytes.NewReader(compressed))
-			defer r.Close()
-			got, err := io.ReadAll(r)
-			if err != nil {
-				errs <- err
-				return
-			}
-			if !bytes.Equal(got, src) {
-				errs <- bytes.ErrTooLarge
-			}
-		}()
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Fatal(err)
-	}
-}
-
-func TestSetWindowSize(t *testing.T) {
-	w := NewWriter(nil)
-	if err := w.SetWindowSize(MinWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.SetWindowSize(MaxWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.SetWindowSize(MinWindowSize - 1); err == nil {
-		t.Fatal("expected error for below min")
-	}
-	if err := w.SetWindowSize(MaxWindowSize + 1); err == nil {
-		t.Fatal("expected error for above max")
-	}
-	if err := w.SetWindowSize(0); err == nil {
-		t.Fatal("expected error for 0")
-	}
-	if err := w.SetWindowSize(-1); err == nil {
-		t.Fatal("expected error for negative")
-	}
-}
-
-func TestSetCRCProducesChecksum(t *testing.T) {
-	src := bytes.Repeat([]byte("crc test "), 200)
-
-	withCRC := NewWriter(nil)
-	withCRC.SetCRC(true)
-	crcFrame := withCRC.AppendCompress(nil, src)
-
-	noCRC := NewWriter(nil)
-	noCRC.SetCRC(false)
-	noCRCFrame := noCRC.AppendCompress(nil, src)
-
-	// CRC adds 4 bytes (checksum) + 1 bit in FHD.
-	if len(crcFrame) <= len(noCRCFrame) {
-		t.Fatalf("CRC frame (%d) should be larger than no-CRC frame (%d)", len(crcFrame), len(noCRCFrame))
-	}
-
-	// Both must decompress correctly.
-	var r Reader
-	for _, frame := range [][]byte{crcFrame, noCRCFrame} {
-		got, err := r.AppendDecompress(nil, frame)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(got, src) {
-			t.Fatal("mismatch")
-		}
-	}
-}
-
-func TestSetWindowSizeRoundTrip(t *testing.T) {
-	for _, wnd := range []int{1 << 16, 1 << 20, 8 << 20} {
-		// Keep data well under window size.
-		src := bytes.Repeat([]byte("wnd "), wnd/8)
-		w := NewWriter(nil)
-		_ = w.SetWindowSize(wnd)
-		frame := w.AppendCompress(nil, src)
-		var r Reader
-		got, err := r.AppendDecompress(nil, frame)
-		if err != nil {
-			t.Fatalf("window %d: %v", wnd, err)
-		}
-		if !bytes.Equal(got, src) {
-			t.Fatalf("window %d: mismatch", wnd)
-		}
-	}
-}
-
 func TestResetContentSize(t *testing.T) {
 	src := []byte("content size test data, exactly this long")
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	w.ResetContentSize(&buf, int64(len(src)))
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
@@ -827,7 +730,7 @@ func TestResetContentSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -841,7 +744,7 @@ func TestResetContentSize(t *testing.T) {
 func TestResetContentSizeNegative(t *testing.T) {
 	src := []byte("negative content size means unknown")
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	w.ResetContentSize(&buf, -1)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
@@ -850,7 +753,7 @@ func TestResetContentSizeNegative(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -863,7 +766,7 @@ func TestResetContentSizeNegative(t *testing.T) {
 
 func TestResetContentSizeMismatch(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	w.ResetContentSize(&buf, 100)
 	if _, err := w.Write([]byte("short")); err != nil {
 		t.Fatal(err)
@@ -876,15 +779,15 @@ func TestResetContentSizeMismatch(t *testing.T) {
 
 func TestAppendCompressPreExistingDst(t *testing.T) {
 	src := []byte("data to compress")
-	w := NewWriter(nil)
+	e := NewEncoder()
 	prefix := []byte("HEADER:")
-	got := w.AppendCompress(prefix, src)
+	got := e.AppendCompress(prefix, src)
 	if !bytes.HasPrefix(got, []byte("HEADER:")) {
 		t.Fatalf("prefix not preserved: %x", got[:7])
 	}
 	// Decompress the frame after the prefix.
-	var r Reader
-	dec, err := r.AppendDecompress(nil, got[7:])
+	var d Decoder
+	dec, err := d.AppendDecompress(nil, got[7:])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -894,12 +797,12 @@ func TestAppendCompressPreExistingDst(t *testing.T) {
 }
 
 func TestAppendCompressEmptyWithCRC(t *testing.T) {
-	w := NewWriter(nil)
-	w.SetCRC(true)
-	frame := w.AppendCompress(nil, nil)
+	e := NewEncoder()
+	e.SetCRC(true)
+	frame := e.AppendCompress(nil, nil)
 
-	var r Reader
-	got, err := r.AppendDecompress(nil, frame)
+	var d Decoder
+	got, err := d.AppendDecompress(nil, frame)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -908,20 +811,20 @@ func TestAppendCompressEmptyWithCRC(t *testing.T) {
 	}
 
 	// Verify CRC is present: frame with CRC should be longer than without.
-	w.SetCRC(false)
-	noCRC := w.AppendCompress(nil, nil)
+	e.SetCRC(false)
+	noCRC := e.AppendCompress(nil, nil)
 	if len(frame) <= len(noCRC) {
 		t.Fatalf("empty CRC frame (%d) should be longer than no-CRC (%d)", len(frame), len(noCRC))
 	}
 }
 
 func TestAppendCompressEmptyNoCRC(t *testing.T) {
-	w := NewWriter(nil)
-	w.SetCRC(false)
-	frame := w.AppendCompress(nil, nil)
+	e := NewEncoder()
+	e.SetCRC(false)
+	frame := e.AppendCompress(nil, nil)
 
-	var r Reader
-	got, err := r.AppendDecompress(nil, frame)
+	var d Decoder
+	got, err := d.AppendDecompress(nil, frame)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -931,19 +834,19 @@ func TestAppendCompressEmptyNoCRC(t *testing.T) {
 }
 
 func TestAppendCompressReuse(t *testing.T) {
-	w := NewWriter(nil)
+	e := NewEncoder()
 	src1 := []byte("first payload")
 	src2 := []byte("second payload, different content")
 
-	c1 := w.AppendCompress(nil, src1)
-	c2 := w.AppendCompress(nil, src2)
+	c1 := e.AppendCompress(nil, src1)
+	c2 := e.AppendCompress(nil, src2)
 
-	var r Reader
-	got1, err := r.AppendDecompress(nil, c1)
+	var d Decoder
+	got1, err := d.AppendDecompress(nil, c1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	got2, err := r.AppendDecompress(nil, c2)
+	got2, err := d.AppendDecompress(nil, c2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -964,11 +867,11 @@ func TestAppendCompressConcurrentAllLevels(t *testing.T) {
 		level := i % (BestCompression + 1)
 		go func() {
 			defer wg.Done()
-			lw := NewWriter(nil)
-			_ = lw.SetLevel(level)
-			compressed := lw.AppendCompress(nil, src)
-			var r Reader
-			got, err := r.AppendDecompress(nil, compressed)
+			le := NewEncoder()
+			_ = le.SetLevel(level)
+			compressed := le.AppendCompress(nil, src)
+			var d Decoder
+			got, err := d.AppendDecompress(nil, compressed)
 			if err != nil {
 				errs <- err
 				return
@@ -987,7 +890,7 @@ func TestAppendCompressConcurrentAllLevels(t *testing.T) {
 
 func TestFlushEmpty(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	if err := w.Flush(); err != nil {
 		t.Fatal(err)
 	}
@@ -996,7 +899,7 @@ func TestFlushEmpty(t *testing.T) {
 
 func TestFlushMultiple(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 
 	parts := []string{"alpha.", "beta.", "gamma."}
 	for _, p := range parts {
@@ -1011,7 +914,7 @@ func TestFlushMultiple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1024,7 +927,7 @@ func TestFlushMultiple(t *testing.T) {
 
 func TestReadFromEmpty(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	n, err := w.ReadFrom(bytes.NewReader(nil))
 	if err != nil {
 		t.Fatal(err)
@@ -1036,7 +939,7 @@ func TestReadFromEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -1067,7 +970,7 @@ func (r *limitedErrReader) Read(p []byte) (int, error) {
 func TestReadFromError(t *testing.T) {
 	readErr := errors.New("source error")
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	_, err := w.ReadFrom(&limitedErrReader{n: 100, err: readErr})
 	if err != readErr {
 		t.Fatalf("expected readErr, got %v", err)
@@ -1081,7 +984,7 @@ func TestReadFromLarge(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	n, err := w.ReadFrom(bytes.NewReader(src))
 	if err != nil {
 		t.Fatal(err)
@@ -1093,7 +996,7 @@ func TestReadFromLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {

--- a/writer_test.go
+++ b/writer_test.go
@@ -283,40 +283,163 @@ func TestWriter_Close(t *testing.T) {
 }
 
 func TestWriter_Reset(t *testing.T) {
-	src1 := []byte("first stream content")
-	src2 := []byte("second stream content after reset")
+	t.Run("preserves_config_across_streams", func(t *testing.T) {
+		src1 := []byte("first stream content")
+		src2 := []byte("second stream content after reset")
 
-	var buf1, buf2 bytes.Buffer
-	w := mustWriter(t, &buf1)
-	_, _ = w.Write(src1)
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
+		var buf1, buf2 bytes.Buffer
+		w := mustWriter(t, &buf1)
+		_, _ = w.Write(src1)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
 
-	w.Reset(&buf2)
-	_, _ = w.Write(src2)
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
+		if err := w.Reset(&buf2); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write(src2)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
 
-	// Verify both streams.
-	for i, tc := range []struct {
-		compressed []byte
-		want       []byte
-	}{
-		{buf1.Bytes(), src1},
-		{buf2.Bytes(), src2},
-	} {
-		r := mustReader(t, bytes.NewReader(tc.compressed))
+		for i, tc := range []struct {
+			compressed []byte
+			want       []byte
+		}{
+			{buf1.Bytes(), src1},
+			{buf2.Bytes(), src2},
+		} {
+			r := mustReader(t, bytes.NewReader(tc.compressed))
+			got, err := io.ReadAll(r)
+			_ = r.Close()
+			if err != nil {
+				t.Fatalf("stream %d: %v", i, err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("stream %d: mismatch", i)
+			}
+		}
+	})
+
+	t.Run("change_options", func(t *testing.T) {
+		src := bytes.Repeat([]byte("reconfigure me across resets. "), 400)
+		w := mustWriter(t, nil)
+		for _, opts := range [][]EncoderOption{
+			{WithEncoderLevel(1)},
+			{WithEncoderLevel(9), WithEncoderCRC(false)},
+			{WithEncoderLevel(3), WithWindowSize(1 << 20), WithLowMemory(true)},
+		} {
+			var buf bytes.Buffer
+			if err := w.Reset(&buf, opts...); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := w.Write(src); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			r := mustReader(t, bytes.NewReader(buf.Bytes()))
+			got, err := io.ReadAll(r)
+			_ = r.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, src) {
+				t.Fatal("mismatch")
+			}
+		}
+	})
+
+	t.Run("change_level_changes_output", func(t *testing.T) {
+		src := bytes.Repeat([]byte("compressible data pattern. "), 500)
+		w := mustWriter(t, nil)
+
+		var raw bytes.Buffer
+		if err := w.Reset(&raw, WithEncoderLevel(0)); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write(src)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		var best bytes.Buffer
+		if err := w.Reset(&best, WithEncoderLevel(9)); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write(src)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		if raw.Len() <= best.Len() {
+			t.Fatalf("level 0 output (%d) not larger than level 9 (%d)", raw.Len(), best.Len())
+		}
+		for _, b := range [][]byte{raw.Bytes(), best.Bytes()} {
+			r := mustReader(t, bytes.NewReader(b))
+			got, _ := io.ReadAll(r)
+			_ = r.Close()
+			if !bytes.Equal(got, src) {
+				t.Fatal("mismatch")
+			}
+		}
+	})
+
+	t.Run("invalid_option", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := mustWriter(t, nil)
+		if err := w.Reset(&buf, WithWindowSize(1)); err == nil {
+			t.Fatal("expected error for out-of-range window size")
+		}
+	})
+
+	t.Run("content_size_known", func(t *testing.T) {
+		src := []byte("content size test data, exactly this long")
+		var buf bytes.Buffer
+		w := mustWriter(t, &buf)
+		if err := w.Reset(&buf, WithContentSize(int64(len(src)))); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
-			t.Fatalf("stream %d: %v", i, err)
+			t.Fatal(err)
 		}
-		if !bytes.Equal(got, tc.want) {
-			t.Fatalf("stream %d: mismatch", i)
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
 		}
-	}
+	})
+
+	t.Run("content_size_negative_is_error", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := mustWriter(t, nil)
+		if err := w.Reset(&buf, WithContentSize(-1)); err == nil {
+			t.Fatal("expected error for negative content size")
+		}
+	})
+
+	t.Run("content_size_mismatch", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := mustWriter(t, &buf)
+		if err := w.Reset(&buf, WithContentSize(100)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte("short")); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err == nil {
+			t.Fatal("expected error for content size mismatch")
+		}
+	})
 }
 
 func TestWriter_Flush(t *testing.T) {
@@ -503,67 +626,6 @@ func TestWriter_ReadFrom(t *testing.T) {
 		}
 		if !bytes.Equal(got, src) {
 			t.Fatal("mismatch")
-		}
-	})
-}
-
-func TestWriter_ResetContentSize(t *testing.T) {
-	t.Run("basic", func(t *testing.T) {
-		src := []byte("content size test data, exactly this long")
-		var buf bytes.Buffer
-		w := mustWriter(t, &buf)
-		w.ResetContentSize(&buf, int64(len(src)))
-		if _, err := w.Write(src); err != nil {
-			t.Fatal(err)
-		}
-		if err := w.Close(); err != nil {
-			t.Fatal(err)
-		}
-
-		r := mustReader(t, bytes.NewReader(buf.Bytes()))
-		got, err := io.ReadAll(r)
-		r.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(got, src) {
-			t.Fatal("mismatch")
-		}
-	})
-
-	t.Run("negative", func(t *testing.T) {
-		src := []byte("negative content size means unknown")
-		var buf bytes.Buffer
-		w := mustWriter(t, &buf)
-		w.ResetContentSize(&buf, -1)
-		if _, err := w.Write(src); err != nil {
-			t.Fatal(err)
-		}
-		if err := w.Close(); err != nil {
-			t.Fatal(err)
-		}
-
-		r := mustReader(t, bytes.NewReader(buf.Bytes()))
-		got, err := io.ReadAll(r)
-		r.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(got, src) {
-			t.Fatal("mismatch")
-		}
-	})
-
-	t.Run("mismatch", func(t *testing.T) {
-		var buf bytes.Buffer
-		w := mustWriter(t, &buf)
-		w.ResetContentSize(&buf, 100)
-		if _, err := w.Write([]byte("short")); err != nil {
-			t.Fatal(err)
-		}
-		err := w.Close()
-		if err == nil {
-			t.Fatal("expected error for content size mismatch")
 		}
 	})
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"io"
 	"math/rand/v2"
-	"sync"
 	"testing"
 )
 
@@ -36,146 +35,256 @@ func roundTrip(t *testing.T, src []byte) {
 	}
 }
 
-func TestWriterEmpty(t *testing.T) {
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if buf.Len() == 0 {
-		t.Fatal("expected non-empty frame for empty input")
-	}
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer r.Close()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("expected empty decode, got %d bytes", len(got))
-	}
-}
-
-func TestWriterOneByte(t *testing.T) {
-	roundTrip(t, []byte{42})
-}
-
-func TestWriterSmall(t *testing.T) {
-	roundTrip(t, []byte("hello, zstd world!"))
-}
-
-func TestWriterMedium(t *testing.T) {
-	src := make([]byte, 1000)
-	for i := range src {
-		src[i] = byte(i % 251)
-	}
-	roundTrip(t, src)
-}
-
-func TestWriterBlockBoundary(t *testing.T) {
-	// Exactly one block.
-	src := make([]byte, maxCompressedBlockSize)
-	for i := range src {
-		src[i] = byte(i * 7)
-	}
-	roundTrip(t, src)
-}
-
-func TestWriterMultiBlock(t *testing.T) {
-	// More than one block.
-	src := make([]byte, maxCompressedBlockSize+1000)
-	for i := range src {
-		src[i] = byte(i * 3)
-	}
-	roundTrip(t, src)
-}
-
-func TestWriterLarge(t *testing.T) {
-	src := make([]byte, 1<<20) // 1MB
-	rng := rand.New(rand.NewPCG(12345, 67890))
-	for i := range src {
-		src[i] = byte(rng.IntN(256))
-	}
-	roundTrip(t, src)
-}
-
-func TestWriterCompressible(t *testing.T) {
-	// Highly compressible data.
-	src := bytes.Repeat([]byte("ABCDEFGH"), 10000)
-	roundTrip(t, src)
-}
-
-func TestWriterAllZeros(t *testing.T) {
-	roundTrip(t, make([]byte, 50000))
-}
-
-func TestWriterMultipleSmallWrites(t *testing.T) {
-	src := []byte("the quick brown fox jumps over the lazy dog, repeatedly. ")
-	src = bytes.Repeat(src, 100)
-
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	for i := 0; i < len(src); i += 7 {
-		end := min(i+7, len(src))
-		_, err := w.Write(src[i:end])
+func TestWriter_Write(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if buf.Len() == 0 {
+			t.Fatal("expected non-empty frame for empty input")
+		}
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer r.Close()
+		got, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
+		if len(got) != 0 {
+			t.Fatalf("expected empty decode, got %d bytes", len(got))
+		}
+	})
 
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
+	t.Run("one_byte", func(t *testing.T) {
+		roundTrip(t, []byte{42})
+	})
+
+	t.Run("small", func(t *testing.T) {
+		roundTrip(t, []byte("hello, zstd world!"))
+	})
+
+	t.Run("medium", func(t *testing.T) {
+		src := make([]byte, 1000)
+		for i := range src {
+			src[i] = byte(i % 251)
+		}
+		roundTrip(t, src)
+	})
+
+	t.Run("block_boundary", func(t *testing.T) {
+		// Exactly one block.
+		src := make([]byte, maxCompressedBlockSize)
+		for i := range src {
+			src[i] = byte(i * 7)
+		}
+		roundTrip(t, src)
+	})
+
+	t.Run("multi_block", func(t *testing.T) {
+		// More than one block.
+		src := make([]byte, maxCompressedBlockSize+1000)
+		for i := range src {
+			src[i] = byte(i * 3)
+		}
+		roundTrip(t, src)
+	})
+
+	t.Run("large", func(t *testing.T) {
+		src := make([]byte, 1<<20) // 1MB
+		rng := rand.New(rand.NewPCG(12345, 67890))
+		for i := range src {
+			src[i] = byte(rng.IntN(256))
+		}
+		roundTrip(t, src)
+	})
+
+	t.Run("compressible", func(t *testing.T) {
+		// Highly compressible data.
+		src := bytes.Repeat([]byte("ABCDEFGH"), 10000)
+		roundTrip(t, src)
+	})
+
+	t.Run("all_zeros", func(t *testing.T) {
+		roundTrip(t, make([]byte, 50000))
+	})
+
+	t.Run("small_chunks", func(t *testing.T) {
+		src := []byte("the quick brown fox jumps over the lazy dog, repeatedly. ")
+		src = bytes.Repeat(src, 100)
+
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		for i := 0; i < len(src); i += 7 {
+			end := min(i+7, len(src))
+			_, err := w.Write(src[i:end])
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("single_byte", func(t *testing.T) {
+		src := []byte("byte by byte writing test, long enough to have content")
+
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		for _, b := range src {
+			_, err := w.Write([]byte{b})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("crc_enabled", func(t *testing.T) {
+		src := []byte("checksum test data")
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		_, _ = w.Write(src)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify readable (CRC checked by reader).
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("no_crc", func(t *testing.T) {
+		src := []byte("no checksum test data, slightly longer to be interesting")
+		var buf bytes.Buffer
+		e := NewEncoder()
+		e.SetCRC(false)
+		w := NewWriter(&buf, e)
+		w.Reset(&buf)
+		_, _ = w.Write(src)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("small_read_buffer", func(t *testing.T) {
+		src := bytes.Repeat([]byte("small buffer read test "), 200)
+
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer func() { _ = r.Close() }()
+
+		// Read in small chunks.
+		var got []byte
+		tmp := make([]byte, 13)
+		for {
+			n, err := r.Read(tmp)
+			got = append(got, tmp[:n]...)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
 }
 
-func TestWriterFlush(t *testing.T) {
+func TestWriter_Write_Count(t *testing.T) {
+	src := []byte("verify write count returns correct values")
 	var buf bytes.Buffer
 	w := NewWriter(&buf, nil)
-	part1 := []byte("first part of data. ")
-	part2 := []byte("second part of data.")
 
-	_, err := w.Write(part1)
-	if err != nil {
-		t.Fatal(err)
+	n, err := w.Write(src[:10])
+	if err != nil || n != 10 {
+		t.Fatalf("Write(10) = %d, %v", n, err)
 	}
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
-	// After flush, some bytes should have been written.
-	if buf.Len() == 0 {
-		t.Fatal("expected output after flush")
-	}
-
-	_, err = w.Write(part2)
-	if err != nil {
-		t.Fatal(err)
+	n, err = w.Write(src[10:])
+	if err != nil || n != len(src)-10 {
+		t.Fatalf("Write(rest) = %d, %v", n, err)
 	}
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
+}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := append(part1, part2...)
-	if !bytes.Equal(got, want) {
-		t.Fatal("mismatch after flush")
+func TestWriter_Write_AfterClose(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf, nil)
+	_, _ = w.Write([]byte("data"))
+	_ = w.Close()
+
+	_, err := w.Write([]byte("more"))
+	if err != ErrEncoderClosed {
+		t.Fatalf("expected ErrEncoderClosed, got %v", err)
 	}
 }
 
-func TestWriterReset(t *testing.T) {
+func TestWriter_Close(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf, nil)
+	_, _ = w.Write([]byte("data"))
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Second close should not panic or error.
+	if err := w.Close(); err != nil {
+		t.Fatal("second close:", err)
+	}
+}
+
+func TestWriter_Reset(t *testing.T) {
 	src1 := []byte("first stream content")
 	src2 := []byte("second stream content after reset")
 
@@ -212,304 +321,253 @@ func TestWriterReset(t *testing.T) {
 	}
 }
 
-func TestWriterWriteAfterClose(t *testing.T) {
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	_, _ = w.Write([]byte("data"))
-	_ = w.Close()
+func TestWriter_Flush(t *testing.T) {
+	t.Run("interleaved", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		part1 := []byte("first part of data. ")
+		part2 := []byte("second part of data.")
 
-	_, err := w.Write([]byte("more"))
-	if err != ErrEncoderClosed {
-		t.Fatalf("expected ErrEncoderClosed, got %v", err)
-	}
-}
-
-func TestWriterDoubleClose(t *testing.T) {
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	_, _ = w.Write([]byte("data"))
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-	// Second close should not panic or error.
-	if err := w.Close(); err != nil {
-		t.Fatal("second close:", err)
-	}
-}
-
-func TestWriterSetLevel(t *testing.T) {
-	e := NewEncoder()
-	if err := e.SetLevel(DefaultCompression); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.SetLevel(NoCompression); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.SetLevel(BestSpeed); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.SetLevel(BestCompression); err != nil {
-		t.Fatal(err)
-	}
-	if err := e.SetLevel(10); err == nil {
-		t.Fatal("expected error for invalid level")
-	}
-	if err := e.SetLevel(-2); err == nil {
-		t.Fatal("expected error for invalid level")
-	}
-}
-
-func TestNoCompressionIsRaw(t *testing.T) {
-	src := bytes.Repeat([]byte("hello world! this is highly compressible data. "), 1000)
-	var buf bytes.Buffer
-	e := NewEncoder()
-	if err := e.SetLevel(NoCompression); err != nil {
-		t.Fatal(err)
-	}
-	w := NewWriter(&buf, e)
-	w.Reset(&buf)
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if buf.Len() < len(src) {
-		t.Errorf("NoCompression reduced size: src=%d compressed=%d", len(src), buf.Len())
-	}
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer r.Close()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("roundtrip mismatch")
-	}
-
-	// Also test AppendCompress path.
-	buf.Reset()
-	e2 := NewEncoder()
-	if err := e2.SetLevel(NoCompression); err != nil {
-		t.Fatal(err)
-	}
-	compressed := e2.AppendCompress(nil, src)
-	if len(compressed) < len(src) {
-		t.Errorf("AppendCompress NoCompression reduced size: src=%d compressed=%d", len(src), len(compressed))
-	}
-	r2 := NewReader(bytes.NewReader(compressed), nil)
-	defer r2.Close()
-	got2, err := io.ReadAll(r2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got2, src) {
-		t.Fatal("AppendCompress roundtrip mismatch")
-	}
-}
-
-func TestWriterAppendCompress(t *testing.T) {
-	src := bytes.Repeat([]byte("encode all test data! "), 500)
-	e := NewEncoder()
-	compressed := e.AppendCompress(nil, src)
-
-	r := NewReader(bytes.NewReader(compressed), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("AppendCompress round-trip mismatch")
-	}
-}
-
-func TestWriterAppendCompressEmpty(t *testing.T) {
-	e := NewEncoder()
-	c1 := e.AppendCompress(nil, nil)
-	c2 := e.AppendCompress(nil, []byte{})
-	if len(c1) == 0 {
-		t.Fatal("expected non-empty frame for nil input")
-	}
-	if !bytes.Equal(c1, c2) {
-		t.Fatal("nil and empty should produce identical frames")
-	}
-	r := NewReader(bytes.NewReader(c1), nil)
-	defer r.Close()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("expected empty decode, got %d bytes", len(got))
-	}
-}
-
-func TestWriterAppendCompressMultiBlock(t *testing.T) {
-	src := make([]byte, maxCompressedBlockSize*2+1000)
-	for i := range src {
-		src[i] = byte(i % 200)
-	}
-	e := NewEncoder()
-	compressed := e.AppendCompress(nil, src)
-
-	r := NewReader(bytes.NewReader(compressed), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("AppendCompress multi-block round-trip mismatch")
-	}
-}
-
-func TestWriterReadFrom(t *testing.T) {
-	src := bytes.Repeat([]byte("ReadFrom test data! "), 1000)
-
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	n, err := w.ReadFrom(bytes.NewReader(src))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != int64(len(src)) {
-		t.Fatalf("ReadFrom returned %d, want %d", n, len(src))
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("ReadFrom round-trip mismatch")
-	}
-}
-
-func TestWriterCRCEnabled(t *testing.T) {
-	src := []byte("checksum test data")
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	_, _ = w.Write(src)
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify readable (CRC checked by reader).
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestWriterNoCRC(t *testing.T) {
-	src := []byte("no checksum test data, slightly longer to be interesting")
-	var buf bytes.Buffer
-	e := NewEncoder()
-	e.SetCRC(false)
-	w := NewWriter(&buf, e)
-	w.Reset(&buf)
-	_, _ = w.Write(src)
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestWriterWriteCountCorrect(t *testing.T) {
-	src := []byte("verify write count returns correct values")
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-
-	n, err := w.Write(src[:10])
-	if err != nil || n != 10 {
-		t.Fatalf("Write(10) = %d, %v", n, err)
-	}
-	n, err = w.Write(src[10:])
-	if err != nil || n != len(src)-10 {
-		t.Fatalf("Write(rest) = %d, %v", n, err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestWriterSingleByteWrites(t *testing.T) {
-	src := []byte("byte by byte writing test, long enough to have content")
-
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	for _, b := range src {
-		_, err := w.Write([]byte{b})
+		_, err := w.Write(part1)
 		if err != nil {
 			t.Fatal(err)
 		}
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer func() { _ = r.Close() }()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestWriterSmallBuffer(t *testing.T) {
-	src := bytes.Repeat([]byte("small buffer read test "), 200)
-
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer func() { _ = r.Close() }()
-
-	// Read in small chunks.
-	var got []byte
-	tmp := make([]byte, 13)
-	for {
-		n, err := r.Read(tmp)
-		got = append(got, tmp[:n]...)
-		if err == io.EOF {
-			break
+		if err := w.Flush(); err != nil {
+			t.Fatal(err)
 		}
+		// After flush, some bytes should have been written.
+		if buf.Len() == 0 {
+			t.Fatal("expected output after flush")
+		}
+
+		_, err = w.Write(part2)
 		if err != nil {
 			t.Fatal(err)
 		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := append(part1, part2...)
+		if !bytes.Equal(got, want) {
+			t.Fatal("mismatch after flush")
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		if err := w.Flush(); err != nil {
+			t.Fatal(err)
+		}
+		_ = w.Close()
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+
+		parts := []string{"alpha.", "beta.", "gamma."}
+		for _, p := range parts {
+			if _, err := w.Write([]byte(p)); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Flush(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		got, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "alpha.beta.gamma." {
+			t.Fatalf("got %q", got)
+		}
+	})
+}
+
+type limitedErrReader struct {
+	n   int
+	err error
+}
+
+func (r *limitedErrReader) Read(p []byte) (int, error) {
+	if r.n <= 0 {
+		return 0, r.err
 	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
+	n := min(len(p), r.n)
+	for i := range n {
+		p[i] = 'x'
 	}
+	r.n -= n
+	return n, nil
+}
+
+func TestWriter_ReadFrom(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		src := bytes.Repeat([]byte("ReadFrom test data! "), 1000)
+
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		n, err := w.ReadFrom(bytes.NewReader(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != int64(len(src)) {
+			t.Fatalf("ReadFrom returned %d, want %d", n, len(src))
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer func() { _ = r.Close() }()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("ReadFrom round-trip mismatch")
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		n, err := w.ReadFrom(bytes.NewReader(nil))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Fatalf("ReadFrom empty returned %d", n)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		got, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected empty, got %d bytes", len(got))
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		readErr := errors.New("source error")
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		_, err := w.ReadFrom(&limitedErrReader{n: 100, err: readErr})
+		if err != readErr {
+			t.Fatalf("expected readErr, got %v", err)
+		}
+	})
+
+	t.Run("large", func(t *testing.T) {
+		src := make([]byte, maxCompressedBlockSize*2+1000)
+		for i := range src {
+			src[i] = byte(i % 199)
+		}
+
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		n, err := w.ReadFrom(bytes.NewReader(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != int64(len(src)) {
+			t.Fatalf("ReadFrom returned %d, want %d", n, len(src))
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		got, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+}
+
+func TestWriter_ResetContentSize(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		src := []byte("content size test data, exactly this long")
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		w.ResetContentSize(&buf, int64(len(src)))
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		got, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		src := []byte("negative content size means unknown")
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		w.ResetContentSize(&buf, -1)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		got, err := io.ReadAll(r)
+		r.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("mismatch", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := NewWriter(&buf, nil)
+		w.ResetContentSize(&buf, 100)
+		if _, err := w.Write([]byte("short")); err != nil {
+			t.Fatal(err)
+		}
+		err := w.Close()
+		if err == nil {
+			t.Fatal("expected error for content size mismatch")
+		}
+	})
 }
 
 func roundTripLevel(t *testing.T, src []byte, level int) {
@@ -539,470 +597,133 @@ func roundTripLevel(t *testing.T, src []byte, level int) {
 	}
 }
 
-func TestAllLevelsSmall(t *testing.T) {
-	src := []byte("the quick brown fox jumps over the lazy dog, repeatedly! ")
-	src = bytes.Repeat(src, 50)
-	for level := NoCompression; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			roundTripLevel(t, src, level)
-		})
-	}
-	// DefaultCompression
-	roundTripLevel(t, src, DefaultCompression)
+func TestWriter_AllLevels(t *testing.T) {
+	t.Run("small", func(t *testing.T) {
+		src := []byte("the quick brown fox jumps over the lazy dog, repeatedly! ")
+		src = bytes.Repeat(src, 50)
+		for level := NoCompression; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				roundTripLevel(t, src, level)
+			})
+		}
+		// DefaultCompression
+		roundTripLevel(t, src, DefaultCompression)
+	})
+
+	t.Run("medium", func(t *testing.T) {
+		src := make([]byte, 50000)
+		rng := rand.New(rand.NewPCG(42, 99))
+		for i := range src {
+			src[i] = byte(rng.IntN(64))
+		}
+		for level := NoCompression; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				roundTripLevel(t, src, level)
+			})
+		}
+	})
+
+	t.Run("large", func(t *testing.T) {
+		src := make([]byte, 1<<20)
+		rng := rand.New(rand.NewPCG(7777, 8888))
+		for i := range src {
+			src[i] = byte(rng.IntN(256))
+		}
+		for level := NoCompression; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				roundTripLevel(t, src, level)
+			})
+		}
+	})
+
+	t.Run("compressible", func(t *testing.T) {
+		src := bytes.Repeat([]byte("ABCDEFGHIJKLMNOP"), 5000)
+		for level := NoCompression; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				roundTripLevel(t, src, level)
+			})
+		}
+	})
+
+	t.Run("all_zeros", func(t *testing.T) {
+		src := make([]byte, 100000)
+		for level := NoCompression; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				roundTripLevel(t, src, level)
+			})
+		}
+	})
+
+	t.Run("multi_block", func(t *testing.T) {
+		src := make([]byte, maxCompressedBlockSize*2+5000)
+		for i := range src {
+			src[i] = byte(i % 251)
+		}
+		for level := 1; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				roundTripLevel(t, src, level)
+			})
+		}
+	})
+
+	t.Run("one_byte", func(t *testing.T) {
+		src := []byte{42}
+		for level := NoCompression; level <= BestCompression; level++ {
+			t.Run("", func(t *testing.T) {
+				roundTripLevel(t, src, level)
+			})
+		}
+	})
 }
 
-func TestAllLevelsMedium(t *testing.T) {
-	src := make([]byte, 50000)
-	rng := rand.New(rand.NewPCG(42, 99))
-	for i := range src {
-		src[i] = byte(rng.IntN(64))
-	}
-	for level := NoCompression; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			roundTripLevel(t, src, level)
-		})
-	}
-}
-
-func TestAllLevelsLarge(t *testing.T) {
-	src := make([]byte, 1<<20)
-	rng := rand.New(rand.NewPCG(7777, 8888))
-	for i := range src {
-		src[i] = byte(rng.IntN(256))
-	}
-	for level := NoCompression; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			roundTripLevel(t, src, level)
-		})
-	}
-}
-
-func TestAllLevelsCompressible(t *testing.T) {
-	src := bytes.Repeat([]byte("ABCDEFGHIJKLMNOP"), 5000)
-	for level := NoCompression; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			roundTripLevel(t, src, level)
-		})
-	}
-}
-
-func TestAllLevelsAllZeros(t *testing.T) {
-	src := make([]byte, 100000)
-	for level := NoCompression; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			roundTripLevel(t, src, level)
-		})
-	}
-}
-
-func TestAllLevelsMultiBlock(t *testing.T) {
-	src := make([]byte, maxCompressedBlockSize*2+5000)
-	for i := range src {
-		src[i] = byte(i % 251)
-	}
-	for level := 1; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			roundTripLevel(t, src, level)
-		})
-	}
-}
-
-func TestAllLevelsOneByte(t *testing.T) {
-	src := []byte{42}
-	for level := NoCompression; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			roundTripLevel(t, src, level)
-		})
-	}
-}
-
-func TestAppendCompressAllLevels(t *testing.T) {
-	src := bytes.Repeat([]byte("AppendCompress test data across levels! "), 500)
-	for level := 1; level <= BestCompression; level++ {
-		t.Run("", func(t *testing.T) {
-			e := NewEncoder()
-			if err := e.SetLevel(level); err != nil {
-				t.Fatal(err)
-			}
-			compressed := e.AppendCompress(nil, src)
-			r := NewReader(bytes.NewReader(compressed), nil)
-			defer func() { _ = r.Close() }()
-			got, err := io.ReadAll(r)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(got, src) {
-				t.Fatalf("AppendCompress mismatch at level %d", level)
-			}
-		})
-	}
-}
-
-func TestLevelSwitching(t *testing.T) {
-	src := bytes.Repeat([]byte("level switching test "), 200)
-	e := NewEncoder()
-	w := NewWriter(nil, e)
-	for level := 1; level <= BestCompression; level++ {
+func TestWriter_ZeroValue(t *testing.T) {
+	t.Run("stream", func(t *testing.T) {
+		src := bytes.Repeat([]byte("zero stream "), 100)
 		var buf bytes.Buffer
-		_ = e.SetLevel(level)
+		var w Writer
 		w.Reset(&buf)
-		_, _ = w.Write(src)
+		if _, err := w.Write(src); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		defer r.Close()
+		got, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatal("mismatch")
+		}
+	})
+
+	t.Run("read_from", func(t *testing.T) {
+		src := bytes.Repeat([]byte("zero readfrom "), 100)
+		var buf bytes.Buffer
+		var w Writer
+		w.Reset(&buf)
+		n, err := w.ReadFrom(bytes.NewReader(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != int64(len(src)) {
+			t.Fatalf("ReadFrom returned %d, want %d", n, len(src))
+		}
 		if err := w.Close(); err != nil {
 			t.Fatal(err)
 		}
 
 		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 		got, err := io.ReadAll(r)
-		_ = r.Close()
+		r.Close()
 		if err != nil {
-			t.Fatalf("level %d: %v", level, err)
+			t.Fatal(err)
 		}
 		if !bytes.Equal(got, src) {
-			t.Fatalf("level %d: mismatch", level)
+			t.Fatal("mismatch")
 		}
-	}
-}
-
-func TestZeroValueWriter(t *testing.T) {
-	src := bytes.Repeat([]byte("zero value writer "), 100)
-	var e Encoder
-	compressed := e.AppendCompress(nil, src)
-
-	r := NewReader(bytes.NewReader(compressed), nil)
-	defer r.Close()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestZeroValueWriterStream(t *testing.T) {
-	src := bytes.Repeat([]byte("zero stream "), 100)
-	var buf bytes.Buffer
-	var w Writer
-	w.Reset(&buf)
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	defer r.Close()
-	got, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestZeroValueWriterConfig(t *testing.T) {
-	src := bytes.Repeat([]byte("zero config "), 100)
-	var e Encoder
-	e.SetCRC(false)
-	compressed := e.AppendCompress(nil, src)
-
-	var d Decoder
-	got, err := d.AppendDecompress(nil, compressed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestResetContentSize(t *testing.T) {
-	src := []byte("content size test data, exactly this long")
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	w.ResetContentSize(&buf, int64(len(src)))
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestResetContentSizeNegative(t *testing.T) {
-	src := []byte("negative content size means unknown")
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	w.ResetContentSize(&buf, -1)
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestResetContentSizeMismatch(t *testing.T) {
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	w.ResetContentSize(&buf, 100)
-	if _, err := w.Write([]byte("short")); err != nil {
-		t.Fatal(err)
-	}
-	err := w.Close()
-	if err == nil {
-		t.Fatal("expected error for content size mismatch")
-	}
-}
-
-func TestAppendCompressPreExistingDst(t *testing.T) {
-	src := []byte("data to compress")
-	e := NewEncoder()
-	prefix := []byte("HEADER:")
-	got := e.AppendCompress(prefix, src)
-	if !bytes.HasPrefix(got, []byte("HEADER:")) {
-		t.Fatalf("prefix not preserved: %x", got[:7])
-	}
-	// Decompress the frame after the prefix.
-	var d Decoder
-	dec, err := d.AppendDecompress(nil, got[7:])
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(dec, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestAppendCompressEmptyWithCRC(t *testing.T) {
-	e := NewEncoder()
-	e.SetCRC(true)
-	frame := e.AppendCompress(nil, nil)
-
-	var d Decoder
-	got, err := d.AppendDecompress(nil, frame)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("expected empty, got %d bytes", len(got))
-	}
-
-	// Verify CRC is present: frame with CRC should be longer than without.
-	e.SetCRC(false)
-	noCRC := e.AppendCompress(nil, nil)
-	if len(frame) <= len(noCRC) {
-		t.Fatalf("empty CRC frame (%d) should be longer than no-CRC (%d)", len(frame), len(noCRC))
-	}
-}
-
-func TestAppendCompressEmptyNoCRC(t *testing.T) {
-	e := NewEncoder()
-	e.SetCRC(false)
-	frame := e.AppendCompress(nil, nil)
-
-	var d Decoder
-	got, err := d.AppendDecompress(nil, frame)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("expected empty, got %d bytes", len(got))
-	}
-}
-
-func TestAppendCompressReuse(t *testing.T) {
-	e := NewEncoder()
-	src1 := []byte("first payload")
-	src2 := []byte("second payload, different content")
-
-	c1 := e.AppendCompress(nil, src1)
-	c2 := e.AppendCompress(nil, src2)
-
-	var d Decoder
-	got1, err := d.AppendDecompress(nil, c1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got2, err := d.AppendDecompress(nil, c2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got1, src1) || !bytes.Equal(got2, src2) {
-		t.Fatal("reuse mismatch")
-	}
-}
-
-func TestAppendCompressConcurrentAllLevels(t *testing.T) {
-	src := bytes.Repeat([]byte("concurrent levels "), 500)
-
-	const goroutines = 10
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
-	errs := make(chan error, goroutines)
-
-	for i := range goroutines {
-		level := i % (BestCompression + 1)
-		go func() {
-			defer wg.Done()
-			le := NewEncoder()
-			_ = le.SetLevel(level)
-			compressed := le.AppendCompress(nil, src)
-			var d Decoder
-			got, err := d.AppendDecompress(nil, compressed)
-			if err != nil {
-				errs <- err
-				return
-			}
-			if !bytes.Equal(got, src) {
-				errs <- bytes.ErrTooLarge
-			}
-		}()
-	}
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		t.Fatal(err)
-	}
-}
-
-func TestFlushEmpty(t *testing.T) {
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	if err := w.Flush(); err != nil {
-		t.Fatal(err)
-	}
-	_ = w.Close()
-}
-
-func TestFlushMultiple(t *testing.T) {
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-
-	parts := []string{"alpha.", "beta.", "gamma."}
-	for _, p := range parts {
-		if _, err := w.Write([]byte(p)); err != nil {
-			t.Fatal(err)
-		}
-		if err := w.Flush(); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "alpha.beta.gamma." {
-		t.Fatalf("got %q", got)
-	}
-}
-
-func TestReadFromEmpty(t *testing.T) {
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	n, err := w.ReadFrom(bytes.NewReader(nil))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 0 {
-		t.Fatalf("ReadFrom empty returned %d", n)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("expected empty, got %d bytes", len(got))
-	}
-}
-
-type limitedErrReader struct {
-	n   int
-	err error
-}
-
-func (r *limitedErrReader) Read(p []byte) (int, error) {
-	if r.n <= 0 {
-		return 0, r.err
-	}
-	n := min(len(p), r.n)
-	for i := range n {
-		p[i] = 'x'
-	}
-	r.n -= n
-	return n, nil
-}
-
-func TestReadFromError(t *testing.T) {
-	readErr := errors.New("source error")
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	_, err := w.ReadFrom(&limitedErrReader{n: 100, err: readErr})
-	if err != readErr {
-		t.Fatalf("expected readErr, got %v", err)
-	}
-}
-
-func TestReadFromLarge(t *testing.T) {
-	src := make([]byte, maxCompressedBlockSize*2+1000)
-	for i := range src {
-		src[i] = byte(i % 199)
-	}
-
-	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
-	n, err := w.ReadFrom(bytes.NewReader(src))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != int64(len(src)) {
-		t.Fatalf("ReadFrom returned %d, want %d", n, len(src))
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
+	})
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -188,7 +188,6 @@ func TestWriter_Write(t *testing.T) {
 		src := []byte("no checksum test data, slightly longer to be interesting")
 		var buf bytes.Buffer
 		w := mustWriter(t, &buf, WithEncoderCRC(false))
-		w.Reset(&buf)
 		_, _ = w.Write(src)
 		if err := w.Close(); err != nil {
 			t.Fatal(err)
@@ -634,7 +633,6 @@ func roundTripLevel(t *testing.T, src []byte, level int) {
 	t.Helper()
 	var buf bytes.Buffer
 	w := mustWriter(t, &buf, WithEncoderLevel(level))
-	w.Reset(&buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal("write:", err)
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -15,7 +15,7 @@ import (
 func roundTrip(t *testing.T, src []byte) {
 	t.Helper()
 	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
+	w := mustWriter(t, &buf)
 	_, err := w.Write(src)
 	if err != nil {
 		t.Fatal("write:", err)
@@ -24,7 +24,7 @@ func roundTrip(t *testing.T, src []byte) {
 		t.Fatal("close:", err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+	r := mustReader(t, bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -38,14 +38,14 @@ func roundTrip(t *testing.T, src []byte) {
 func TestWriter_Write(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		if err := w.Close(); err != nil {
 			t.Fatal(err)
 		}
 		if buf.Len() == 0 {
 			t.Fatal("expected non-empty frame for empty input")
 		}
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer r.Close()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -114,7 +114,7 @@ func TestWriter_Write(t *testing.T) {
 		src = bytes.Repeat(src, 100)
 
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		for i := 0; i < len(src); i += 7 {
 			end := min(i+7, len(src))
 			_, err := w.Write(src[i:end])
@@ -126,7 +126,7 @@ func TestWriter_Write(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -141,7 +141,7 @@ func TestWriter_Write(t *testing.T) {
 		src := []byte("byte by byte writing test, long enough to have content")
 
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		for _, b := range src {
 			_, err := w.Write([]byte{b})
 			if err != nil {
@@ -152,7 +152,7 @@ func TestWriter_Write(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -166,14 +166,14 @@ func TestWriter_Write(t *testing.T) {
 	t.Run("crc_enabled", func(t *testing.T) {
 		src := []byte("checksum test data")
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		_, _ = w.Write(src)
 		if err := w.Close(); err != nil {
 			t.Fatal(err)
 		}
 
 		// Verify readable (CRC checked by reader).
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -187,16 +187,14 @@ func TestWriter_Write(t *testing.T) {
 	t.Run("no_crc", func(t *testing.T) {
 		src := []byte("no checksum test data, slightly longer to be interesting")
 		var buf bytes.Buffer
-		e := NewEncoder()
-		e.SetCRC(false)
-		w := NewWriter(&buf, e)
+		w := mustWriter(t, &buf, WithEncoderCRC(false))
 		w.Reset(&buf)
 		_, _ = w.Write(src)
 		if err := w.Close(); err != nil {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -211,7 +209,7 @@ func TestWriter_Write(t *testing.T) {
 		src := bytes.Repeat([]byte("small buffer read test "), 200)
 
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
 		}
@@ -219,7 +217,7 @@ func TestWriter_Write(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer func() { _ = r.Close() }()
 
 		// Read in small chunks.
@@ -244,7 +242,7 @@ func TestWriter_Write(t *testing.T) {
 func TestWriter_Write_Count(t *testing.T) {
 	src := []byte("verify write count returns correct values")
 	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
+	w := mustWriter(t, &buf)
 
 	n, err := w.Write(src[:10])
 	if err != nil || n != 10 {
@@ -261,7 +259,7 @@ func TestWriter_Write_Count(t *testing.T) {
 
 func TestWriter_Write_AfterClose(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
+	w := mustWriter(t, &buf)
 	_, _ = w.Write([]byte("data"))
 	_ = w.Close()
 
@@ -273,7 +271,7 @@ func TestWriter_Write_AfterClose(t *testing.T) {
 
 func TestWriter_Close(t *testing.T) {
 	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
+	w := mustWriter(t, &buf)
 	_, _ = w.Write([]byte("data"))
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
@@ -289,7 +287,7 @@ func TestWriter_Reset(t *testing.T) {
 	src2 := []byte("second stream content after reset")
 
 	var buf1, buf2 bytes.Buffer
-	w := NewWriter(&buf1, nil)
+	w := mustWriter(t, &buf1)
 	_, _ = w.Write(src1)
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
@@ -309,7 +307,7 @@ func TestWriter_Reset(t *testing.T) {
 		{buf1.Bytes(), src1},
 		{buf2.Bytes(), src2},
 	} {
-		r := NewReader(bytes.NewReader(tc.compressed), nil)
+		r := mustReader(t, bytes.NewReader(tc.compressed))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -324,7 +322,7 @@ func TestWriter_Reset(t *testing.T) {
 func TestWriter_Flush(t *testing.T) {
 	t.Run("interleaved", func(t *testing.T) {
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		part1 := []byte("first part of data. ")
 		part2 := []byte("second part of data.")
 
@@ -348,7 +346,7 @@ func TestWriter_Flush(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -362,7 +360,7 @@ func TestWriter_Flush(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		if err := w.Flush(); err != nil {
 			t.Fatal(err)
 		}
@@ -371,7 +369,7 @@ func TestWriter_Flush(t *testing.T) {
 
 	t.Run("multiple", func(t *testing.T) {
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 
 		parts := []string{"alpha.", "beta.", "gamma."}
 		for _, p := range parts {
@@ -386,7 +384,7 @@ func TestWriter_Flush(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -420,7 +418,7 @@ func TestWriter_ReadFrom(t *testing.T) {
 		src := bytes.Repeat([]byte("ReadFrom test data! "), 1000)
 
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		n, err := w.ReadFrom(bytes.NewReader(src))
 		if err != nil {
 			t.Fatal(err)
@@ -432,7 +430,7 @@ func TestWriter_ReadFrom(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer func() { _ = r.Close() }()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -445,7 +443,7 @@ func TestWriter_ReadFrom(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		n, err := w.ReadFrom(bytes.NewReader(nil))
 		if err != nil {
 			t.Fatal(err)
@@ -457,7 +455,7 @@ func TestWriter_ReadFrom(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -471,7 +469,7 @@ func TestWriter_ReadFrom(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		readErr := errors.New("source error")
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		_, err := w.ReadFrom(&limitedErrReader{n: 100, err: readErr})
 		if err != readErr {
 			t.Fatalf("expected readErr, got %v", err)
@@ -485,7 +483,7 @@ func TestWriter_ReadFrom(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		n, err := w.ReadFrom(bytes.NewReader(src))
 		if err != nil {
 			t.Fatal(err)
@@ -497,7 +495,7 @@ func TestWriter_ReadFrom(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -513,7 +511,7 @@ func TestWriter_ResetContentSize(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		src := []byte("content size test data, exactly this long")
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		w.ResetContentSize(&buf, int64(len(src)))
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
@@ -522,7 +520,7 @@ func TestWriter_ResetContentSize(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -536,7 +534,7 @@ func TestWriter_ResetContentSize(t *testing.T) {
 	t.Run("negative", func(t *testing.T) {
 		src := []byte("negative content size means unknown")
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		w.ResetContentSize(&buf, -1)
 		if _, err := w.Write(src); err != nil {
 			t.Fatal(err)
@@ -545,7 +543,7 @@ func TestWriter_ResetContentSize(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {
@@ -558,7 +556,7 @@ func TestWriter_ResetContentSize(t *testing.T) {
 
 	t.Run("mismatch", func(t *testing.T) {
 		var buf bytes.Buffer
-		w := NewWriter(&buf, nil)
+		w := mustWriter(t, &buf)
 		w.ResetContentSize(&buf, 100)
 		if _, err := w.Write([]byte("short")); err != nil {
 			t.Fatal(err)
@@ -573,11 +571,7 @@ func TestWriter_ResetContentSize(t *testing.T) {
 func roundTripLevel(t *testing.T, src []byte, level int) {
 	t.Helper()
 	var buf bytes.Buffer
-	e := NewEncoder()
-	if err := e.SetLevel(level); err != nil {
-		t.Fatal(err)
-	}
-	w := NewWriter(&buf, e)
+	w := mustWriter(t, &buf, WithEncoderLevel(level))
 	w.Reset(&buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal("write:", err)
@@ -586,7 +580,7 @@ func roundTripLevel(t *testing.T, src []byte, level int) {
 		t.Fatal("close:", err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+	r := mustReader(t, bytes.NewReader(buf.Bytes()))
 	defer func() { _ = r.Close() }()
 	got, err := io.ReadAll(r)
 	if err != nil {
@@ -689,7 +683,7 @@ func TestWriter_ZeroValue(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		defer r.Close()
 		got, err := io.ReadAll(r)
 		if err != nil {
@@ -716,7 +710,7 @@ func TestWriter_ZeroValue(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		r.Close()
 		if err != nil {

--- a/zstd.go
+++ b/zstd.go
@@ -85,7 +85,7 @@ func (e *ErrWindowSizeExceeded) Is(target error) bool {
 }
 
 // ErrDecodedSizeExceeded is returned when decompression would produce more
-// bytes than the limit configured with [Decoder.SetMaxSize].
+// bytes than the limit configured with [WithDecoderMaxSize].
 type ErrDecodedSizeExceeded struct {
 	Allowed, Produced int64
 }

--- a/zstd.go
+++ b/zstd.go
@@ -84,6 +84,23 @@ func (e *ErrWindowSizeExceeded) Is(target error) bool {
 	return ok
 }
 
+// ErrDecodedSizeExceeded is returned when decompression would produce more
+// bytes than the limit configured with [Decoder.SetMaxSize].
+type ErrDecodedSizeExceeded struct {
+	Allowed, Produced int64
+}
+
+// Error implements the error interface.
+func (e *ErrDecodedSizeExceeded) Error() string {
+	return fmt.Sprintf("decoded size exceeded (produced %d, allowed %d)", e.Produced, e.Allowed)
+}
+
+// Is reports whether target is an *ErrDecodedSizeExceeded.
+func (e *ErrDecodedSizeExceeded) Is(target error) bool {
+	_, ok := target.(*ErrDecodedSizeExceeded)
+	return ok
+}
+
 // Errors returned by the zstd encoder and decoder.
 var (
 	ErrUnknownDictionary = errors.New("unknown dictionary")

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -18,7 +18,7 @@ func TestRoundTripStreaming(t *testing.T) {
 	src := bytes.Repeat([]byte("streaming round-trip test data! "), 500)
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
+	w := mustWriter(t, &buf)
 	// Write one byte at a time.
 	for _, b := range src {
 		if _, err := w.Write([]byte{b}); err != nil {
@@ -29,7 +29,7 @@ func TestRoundTripStreaming(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+	r := mustReader(t, bytes.NewReader(buf.Bytes()))
 	// Read one byte at a time.
 	var got []byte
 	tmp := make([]byte, 1)
@@ -60,7 +60,7 @@ func TestRoundTripLarge(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf, nil)
+	w := mustWriter(t, &buf)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestRoundTripLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+	r := mustReader(t, bytes.NewReader(buf.Bytes()))
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -80,12 +80,12 @@ func TestRoundTripLarge(t *testing.T) {
 }
 
 func TestConcatenatedFrames(t *testing.T) {
-	e := NewEncoder()
+	e := mustEncoder(t)
 	frame1 := e.AppendCompress(nil, []byte("frame one "))
 	frame2 := e.AppendCompress(nil, []byte("frame two"))
 
 	combined := append(frame1, frame2...)
-	r := NewReader(bytes.NewReader(combined), nil)
+	r := mustReader(t, bytes.NewReader(combined))
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -100,7 +100,7 @@ func TestIOCopy(t *testing.T) {
 	src := bytes.Repeat([]byte("io.Copy integration test "), 1000)
 
 	var compressed bytes.Buffer
-	w := NewWriter(&compressed, nil)
+	w := mustWriter(t, &compressed)
 	n, err := io.Copy(w, bytes.NewReader(src))
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +112,7 @@ func TestIOCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(compressed.Bytes()), nil)
+	r := mustReader(t, bytes.NewReader(compressed.Bytes()))
 	var decompressed bytes.Buffer
 	_, err = io.Copy(&decompressed, r)
 	_ = r.Close()
@@ -125,7 +125,7 @@ func TestIOCopy(t *testing.T) {
 }
 
 func TestResetCycles(t *testing.T) {
-	w := NewWriter(nil, nil)
+	w := mustWriter(t, nil)
 	for i := range 50 {
 		var buf bytes.Buffer
 		w.Reset(&buf)
@@ -138,7 +138,7 @@ func TestResetCycles(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
+		r := mustReader(t, bytes.NewReader(buf.Bytes()))
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -178,13 +178,10 @@ func TestAllLevelsRoundTrip(t *testing.T) {
 	for _, input := range inputs {
 		t.Run(input.name, func(t *testing.T) {
 			for level := NoCompression; level <= BestCompression; level++ {
-				e := NewEncoder()
-				if err := e.SetLevel(level); err != nil {
-					t.Fatal(err)
-				}
+				e := mustEncoder(t, WithEncoderLevel(level))
 				compressed := e.AppendCompress(nil, input.data)
 
-				r := NewReader(bytes.NewReader(compressed), nil)
+				r := mustReader(t, bytes.NewReader(compressed))
 				got, err := io.ReadAll(r)
 				_ = r.Close()
 				if err != nil {
@@ -265,7 +262,7 @@ func TestErrWindowSizeExceeded_Is(t *testing.T) {
 
 func TestConcurrentReadersFromSameFrame(t *testing.T) {
 	src := bytes.Repeat([]byte("shared frame data "), 500)
-	e := NewEncoder()
+	e := mustEncoder(t)
 	compressed := e.AppendCompress(nil, src)
 
 	const goroutines = 8
@@ -276,7 +273,7 @@ func TestConcurrentReadersFromSameFrame(t *testing.T) {
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			r := NewReader(bytes.NewReader(compressed), nil)
+			r := mustReader(t, bytes.NewReader(compressed))
 			got, err := io.ReadAll(r)
 			r.Close()
 			if err != nil {
@@ -303,8 +300,8 @@ func TestAppendConcurrentBidirectional(t *testing.T) {
 		make([]byte, 50000),
 	}
 
-	e := NewEncoder()
-	dec := NewDecoder()
+	e := mustEncoder(t)
+	dec := mustDecoder(t)
 
 	// Pre-compress all inputs.
 	compressed := make([][]byte, len(inputs))

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -18,7 +18,7 @@ func TestRoundTripStreaming(t *testing.T) {
 	src := bytes.Repeat([]byte("streaming round-trip test data! "), 500)
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	// Write one byte at a time.
 	for _, b := range src {
 		if _, err := w.Write([]byte{b}); err != nil {
@@ -29,7 +29,7 @@ func TestRoundTripStreaming(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	// Read one byte at a time.
 	var got []byte
 	tmp := make([]byte, 1)
@@ -60,7 +60,7 @@ func TestRoundTripLarge(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	w := NewWriter(&buf)
+	w := NewWriter(&buf, nil)
 	if _, err := w.Write(src); err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestRoundTripLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -80,12 +80,12 @@ func TestRoundTripLarge(t *testing.T) {
 }
 
 func TestConcatenatedFrames(t *testing.T) {
-	w := NewWriter(nil)
-	frame1 := w.AppendCompress(nil, []byte("frame one "))
-	frame2 := w.AppendCompress(nil, []byte("frame two"))
+	e := NewEncoder()
+	frame1 := e.AppendCompress(nil, []byte("frame one "))
+	frame2 := e.AppendCompress(nil, []byte("frame two"))
 
 	combined := append(frame1, frame2...)
-	r := NewReader(bytes.NewReader(combined))
+	r := NewReader(bytes.NewReader(combined), nil)
 	got, err := io.ReadAll(r)
 	_ = r.Close()
 	if err != nil {
@@ -100,7 +100,7 @@ func TestIOCopy(t *testing.T) {
 	src := bytes.Repeat([]byte("io.Copy integration test "), 1000)
 
 	var compressed bytes.Buffer
-	w := NewWriter(&compressed)
+	w := NewWriter(&compressed, nil)
 	n, err := io.Copy(w, bytes.NewReader(src))
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +112,7 @@ func TestIOCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(compressed.Bytes()))
+	r := NewReader(bytes.NewReader(compressed.Bytes()), nil)
 	var decompressed bytes.Buffer
 	_, err = io.Copy(&decompressed, r)
 	_ = r.Close()
@@ -125,7 +125,7 @@ func TestIOCopy(t *testing.T) {
 }
 
 func TestResetCycles(t *testing.T) {
-	w := NewWriter(nil)
+	w := NewWriter(nil, nil)
 	for i := range 50 {
 		var buf bytes.Buffer
 		w.Reset(&buf)
@@ -138,7 +138,7 @@ func TestResetCycles(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		r := NewReader(bytes.NewReader(buf.Bytes()))
+		r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 		got, err := io.ReadAll(r)
 		_ = r.Close()
 		if err != nil {
@@ -178,13 +178,13 @@ func TestAllLevelsRoundTrip(t *testing.T) {
 	for _, input := range inputs {
 		t.Run(input.name, func(t *testing.T) {
 			for level := NoCompression; level <= BestCompression; level++ {
-				w := NewWriter(nil)
-				if err := w.SetLevel(level); err != nil {
+				e := NewEncoder()
+				if err := e.SetLevel(level); err != nil {
 					t.Fatal(err)
 				}
-				compressed := w.AppendCompress(nil, input.data)
+				compressed := e.AppendCompress(nil, input.data)
 
-				r := NewReader(bytes.NewReader(compressed))
+				r := NewReader(bytes.NewReader(compressed), nil)
 				got, err := io.ReadAll(r)
 				_ = r.Close()
 				if err != nil {
@@ -263,8 +263,8 @@ func TestErrWindowSizeExceededIs(t *testing.T) {
 
 func TestConcurrentReadersFromSameFrame(t *testing.T) {
 	src := bytes.Repeat([]byte("shared frame data "), 500)
-	w := NewWriter(nil)
-	compressed := w.AppendCompress(nil, src)
+	e := NewEncoder()
+	compressed := e.AppendCompress(nil, src)
 
 	const goroutines = 8
 	var wg sync.WaitGroup
@@ -274,7 +274,7 @@ func TestConcurrentReadersFromSameFrame(t *testing.T) {
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			r := NewReader(bytes.NewReader(compressed))
+			r := NewReader(bytes.NewReader(compressed), nil)
 			got, err := io.ReadAll(r)
 			r.Close()
 			if err != nil {
@@ -301,13 +301,13 @@ func TestAppendConcurrentBidirectional(t *testing.T) {
 		make([]byte, 50000),
 	}
 
-	w := NewWriter(nil)
-	r := NewReader(nil)
+	e := NewEncoder()
+	dec := NewDecoder()
 
 	// Pre-compress all inputs.
 	compressed := make([][]byte, len(inputs))
 	for i, src := range inputs {
-		compressed[i] = w.AppendCompress(nil, src)
+		compressed[i] = e.AppendCompress(nil, src)
 	}
 
 	const goroutines = 16
@@ -322,10 +322,10 @@ func TestAppendConcurrentBidirectional(t *testing.T) {
 			src := inputs[idx]
 
 			// Compress.
-			c := w.AppendCompress(nil, src)
+			c := e.AppendCompress(nil, src)
 
 			// Decompress the pre-made frame.
-			got, err := r.AppendDecompress(nil, compressed[idx])
+			got, err := dec.AppendDecompress(nil, compressed[idx])
 			if err != nil {
 				errs <- fmt.Errorf("decompress %d: %w", idx, err)
 				return
@@ -336,7 +336,7 @@ func TestAppendConcurrentBidirectional(t *testing.T) {
 			}
 
 			// Decompress what we just compressed.
-			got, err = r.AppendDecompress(nil, c)
+			got, err = dec.AppendDecompress(nil, c)
 			if err != nil {
 				errs <- fmt.Errorf("re-decompress %d: %w", idx, err)
 				return
@@ -380,19 +380,18 @@ func TestZeroValueReaderWriteTo(t *testing.T) {
 }
 
 func TestZeroValueReaderConfig(t *testing.T) {
-	var r Reader
-	if err := r.SetMaxWindowSize(MaxWindowSize); err != nil {
+	d := NewDecoder()
+	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
 		t.Fatal(err)
 	}
 	frame := buildRawFrame([]byte("config"))
-	got, err := r.AppendDecompress(nil, frame)
+	got, err := d.AppendDecompress(nil, frame)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(got) != "config" {
 		t.Fatalf("got %q", got)
 	}
-	r.Close()
 }
 
 func TestZeroValueWriterReset(t *testing.T) {
@@ -407,7 +406,7 @@ func TestZeroValueWriterReset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {
@@ -434,7 +433,7 @@ func TestZeroValueWriterReadFrom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewReader(bytes.NewReader(buf.Bytes()))
+	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
 	got, err := io.ReadAll(r)
 	r.Close()
 	if err != nil {

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -360,3 +360,39 @@ func randTestBytes(n int, seed uint64) []byte {
 	}
 	return b
 }
+
+func mustEncoder(tb testing.TB, opts ...EncoderOption) *Encoder {
+	tb.Helper()
+	e, err := NewEncoder(opts...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return e
+}
+
+func mustDecoder(tb testing.TB, opts ...DecoderOption) *Decoder {
+	tb.Helper()
+	d, err := NewDecoder(opts...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return d
+}
+
+func mustWriter(tb testing.TB, w io.Writer, opts ...EncoderOption) *Writer {
+	tb.Helper()
+	wr, err := NewWriter(w, opts...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return wr
+}
+
+func mustReader(tb testing.TB, r io.Reader, opts ...DecoderOption) *Reader {
+	tb.Helper()
+	z, err := NewReader(r, opts...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return z
+}

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -273,7 +273,11 @@ func TestConcurrentReadersFromSameFrame(t *testing.T) {
 	for range goroutines {
 		go func() {
 			defer wg.Done()
-			r := mustReader(t, bytes.NewReader(compressed))
+			r, err := NewReader(bytes.NewReader(compressed))
+			if err != nil {
+				errs <- err
+				return
+			}
 			got, err := io.ReadAll(r)
 			r.Close()
 			if err != nil {

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -198,7 +198,7 @@ func TestAllLevelsRoundTrip(t *testing.T) {
 	}
 }
 
-func TestErrCorruptedError(t *testing.T) {
+func TestErrCorrupted_Error(t *testing.T) {
 	tests := []struct {
 		name string
 		err  *ErrCorrupted
@@ -217,14 +217,23 @@ func TestErrCorruptedError(t *testing.T) {
 	}
 }
 
-func TestErrCorruptedIs(t *testing.T) {
-	err := corruptedError("test")
-	if !errors.Is(err, &ErrCorrupted{}) {
-		t.Fatal("errors.Is should match any *ErrCorrupted")
-	}
+func TestErrCorrupted_Is(t *testing.T) {
+	t.Run("matches_any", func(t *testing.T) {
+		err := corruptedError("test")
+		if !errors.Is(err, &ErrCorrupted{}) {
+			t.Fatal("errors.Is should match any *ErrCorrupted")
+		}
+	})
+
+	t.Run("not_other", func(t *testing.T) {
+		err := corruptedError("x")
+		if errors.Is(err, io.EOF) {
+			t.Fatal("ErrCorrupted should not match io.EOF")
+		}
+	})
 }
 
-func TestErrCorruptedUnwrap(t *testing.T) {
+func TestErrCorrupted_Unwrap(t *testing.T) {
 	inner := io.ErrUnexpectedEOF
 	err := &ErrCorrupted{msg: "wrapper", err: inner}
 	if !errors.Is(err, inner) {
@@ -236,14 +245,7 @@ func TestErrCorruptedUnwrap(t *testing.T) {
 	}
 }
 
-func TestErrCorruptedNotIsOther(t *testing.T) {
-	err := corruptedError("x")
-	if errors.Is(err, io.EOF) {
-		t.Fatal("ErrCorrupted should not match io.EOF")
-	}
-}
-
-func TestErrWindowSizeExceededError(t *testing.T) {
+func TestErrWindowSizeExceeded_Error(t *testing.T) {
 	err := &ErrWindowSizeExceeded{Allowed: 1024, Requested: 4096}
 	s := err.Error()
 	if !bytes.Contains([]byte(s), []byte("1024")) || !bytes.Contains([]byte(s), []byte("4096")) {
@@ -251,7 +253,7 @@ func TestErrWindowSizeExceededError(t *testing.T) {
 	}
 }
 
-func TestErrWindowSizeExceededIs(t *testing.T) {
+func TestErrWindowSizeExceeded_Is(t *testing.T) {
 	err := &ErrWindowSizeExceeded{Allowed: 1, Requested: 2}
 	if !errors.Is(err, &ErrWindowSizeExceeded{}) {
 		t.Fatal("errors.Is should match any *ErrWindowSizeExceeded")
@@ -360,86 +362,4 @@ func randTestBytes(n int, seed uint64) []byte {
 		b[i] = byte(rng.IntN(256))
 	}
 	return b
-}
-
-func TestZeroValueReaderWriteTo(t *testing.T) {
-	frame := buildRawFrame([]byte("zero writeto"))
-	var r Reader
-	if err := r.Reset(bytes.NewReader(frame)); err != nil {
-		t.Fatal(err)
-	}
-	var buf bytes.Buffer
-	n, err := r.WriteTo(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != 12 || buf.String() != "zero writeto" {
-		t.Fatalf("got %d %q", n, buf.String())
-	}
-	r.Close()
-}
-
-func TestZeroValueReaderConfig(t *testing.T) {
-	d := NewDecoder()
-	if err := d.SetMaxWindowSize(MaxWindowSize); err != nil {
-		t.Fatal(err)
-	}
-	frame := buildRawFrame([]byte("config"))
-	got, err := d.AppendDecompress(nil, frame)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(got) != "config" {
-		t.Fatalf("got %q", got)
-	}
-}
-
-func TestZeroValueWriterReset(t *testing.T) {
-	src := bytes.Repeat([]byte("zero reset "), 100)
-	var buf bytes.Buffer
-	var w Writer
-	w.Reset(&buf)
-	if _, err := w.Write(src); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
-}
-
-func TestZeroValueWriterReadFrom(t *testing.T) {
-	src := bytes.Repeat([]byte("zero readfrom "), 100)
-	var buf bytes.Buffer
-	var w Writer
-	w.Reset(&buf)
-	n, err := w.ReadFrom(bytes.NewReader(src))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != int64(len(src)) {
-		t.Fatalf("ReadFrom returned %d, want %d", n, len(src))
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	r := NewReader(bytes.NewReader(buf.Bytes()), nil)
-	got, err := io.ReadAll(r)
-	r.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, src) {
-		t.Fatal("mismatch")
-	}
 }


### PR DESCRIPTION
Configuration moved from setter methods on a pre-built config object to functional options passed at construction. The same option type is shared by each side's two constructors.

 - Based off #24 - but exported Encoder/Decoder types can be removed.

```go
// Before:
e := zstd.NewEncoder()
e.SetLevel(9)
w := zstd.NewWriter(&buf, e)   // hand the encoder to the writer

// After:
w, err := zstd.NewWriter(&buf, zstd.WithEncoderLevel(9))
```

New API surface

```go
type EncoderOption func(*Encoder) error
type DecoderOption func(*Decoder) error

func NewEncoder(opts ...EncoderOption) (*Encoder, error)
func NewWriter(w io.Writer, opts ...EncoderOption) (*Writer, error)
func NewDecoder(opts ...DecoderOption) (*Decoder, error)
func NewReader(r io.Reader, opts ...DecoderOption) (*Reader, error)
```

Options (validation logic moved verbatim from the old setters):
- Encoder: WithEncoderLevel, WithWindowSize, WithLowMemory, WithEncoderCRC, WithEncoderDict, WithEncoderRawDict
- Decoder: WithDecoderMaxWindow, WithDecoderMaxSize, WithDecoderDict, WithDecoderRawDict

Reset now accepts options (both return error):
```go
  func (w *Writer) Reset(wr io.Writer, opts ...EncoderOption) error
  func (z *Reader) Reset(r io.Reader, opts ...DecoderOption) error
```
Options are applied to the Writer/Reader's own private cfg before the reset. Any option can be changed — Writer.Reset already rebuilds the encoder from cfg each call (so changes take effect immediately), and the Reader picks up cfg.o at the next frame. Passing no options preserves the current configuration. On an invalid option, Reset returns the error without touching stream state.

`ResetContentSize` was removed, replaced by a new WithContentSize(int64) EncoderOption (encoder.go). It's streaming-only (one-shot AppendCompress always records the exact len(src) and ignores it), 0 = unknown, negative errors, and — like every option — it persists across Reset calls until changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated encoder and decoder APIs for one-shot compression and decompression.
  - Added configurable compression levels, window and output-size limits, CRCs, low-memory mode, content sizes, and dictionaries.
  - Added support for concurrent encoder/decoder use and concatenated frames.
  - Added clear errors when decoded output exceeds configured limits.

- **Documentation**
  - Updated API guidance, including zero-value usage and append-method locations.
  - Updated examples to demonstrate the new constructor and option-based APIs.

- **Compatibility**
  - Streaming reader and writer configuration now uses constructor and reset options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->